### PR TITLE
implement mStable mUSD strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Mainnet fork testing environment as well as efficiency due to caching.
 
 All tests are located under the `test` folder.
 
-1. Run `npx hardhat test [test file location]`: `npx hardhat test ./test/curve/aave.js`. This will produce the following output:
+1. Run `npx hardhat test [test file location]`: `npx hardhat test ./test/curve/aave.js` (if for some reason the NodeJS heap runs out of memory, make sure to explicitly increase its size via `export NODE_OPTIONS=--max_old_space_size=4096`). This will produce the following output:
   ```
   Polygon Mainnet Curve Aave
 Impersonating...

--- a/contracts/strategies/mstable/MStableStrategy.sol
+++ b/contracts/strategies/mstable/MStableStrategy.sol
@@ -1,0 +1,451 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/math/Math.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "../../base/interface/uniswap/IUniswapV2Router02.sol";
+import "../../base/interface/IVault.sol";
+import "../../base/upgradability/BaseUpgradeableStrategy.sol";
+import "../../base/interface/uniswap/IUniswapV2Pair.sol";
+import "./interfaces/IStakingRewardsWithPlatformToken.sol";
+import "./interfaces/ISavingsContract.sol";
+import "./interfaces/IBVault.sol";
+import "./interfaces/IMasset.sol";
+
+import 'hardhat/console.sol';
+
+contract MStableStrategy is BaseUpgradeableStrategy {
+    using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+
+    address public constant dai = address(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063);
+    address public constant musd = address(0xE840B73E5287865EEc17d250bFb1536704B43B21);
+    address public constant imUSD = address(0x5290Ad3d83476CA6A2b178Cd9727eE1EF72432af);
+
+    bytes32 public constant sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    bytes32 public constant balancerDex = bytes32(0x9e73ce1e99df7d45bc513893badf42bc38069f1564ee511b0c8988f72f127b13);
+    bytes32 public constant quickDex = bytes32(0x7bfa33731cff39bf8528ed70e5709ec0b799f5230ae0e1856a15d99aa053da30);
+    bytes32 public constant mstableDex = bytes32(0x57a5a8ea4df7587ebb4c9aaa2bb3c9f9d459b4962f8b74c320c85916983e67db);
+
+    address public constant quickswapRouterV2 = address(0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff);
+    address public constant sushiswapRouterV2 = address(0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506);
+    address public constant balancerRouter = address(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
+
+    // additional storage slots (on top of BaseUpgradeableStrategy ones) are defined here
+    bytes32 internal constant _SAVINGS_CONTRACT = 0x0500701c69c8b4e491f4e02f33040eaeadaae0eb72a88de7ae51e35a0e286a66;
+
+    // this would be reset on each upgrade
+    mapping (address => mapping (address => bytes32)) public storedLiquidationDexes;
+    mapping (address => mapping (address => bytes32)) public storedBalancerPoolIds;
+    address[] public rewardTokens;
+
+    constructor() public BaseUpgradeableStrategy() {
+        assert(_SAVINGS_CONTRACT == bytes32(uint256(keccak256("eip1967.strategyStorage.savingsContract")) - 1));
+    }
+
+    function _initializeStrategy(
+        address _storage,
+        address _underlying,
+        address _vault,
+        address _rewardPool,
+        address _rewardToken
+    ) public initializer {
+        BaseUpgradeableStrategy.initialize(
+            _storage,
+            _underlying,
+            _vault,
+            _rewardPool,
+            _rewardToken,
+            80, // profit sharing numerator
+            1000, // profit sharing denominator
+            true, // sell
+            1e18, // sell floor
+            12 hours // implementation change delay
+        );
+
+        rewardTokens = new address[](0);
+    }
+
+    function depositArbCheck() public pure returns(bool) {
+        return true;
+    }
+
+
+    // If the return value is MAX_UINT256, it means that
+    // the specified reward token is not in the list
+    function getRewardTokenIndex(address rt) public view returns(uint256) {
+      for(uint i = 0 ; i < rewardTokens.length ; i++){
+        if(rewardTokens[i] == rt)
+          return i;
+      }
+      return uint256(-1);
+    }
+
+    function addRewardToken(address rt) public onlyGovernance {
+      require(getRewardTokenIndex(rt) == uint256(-1), "Reward token already exists");
+      rewardTokens.push(rt);
+    }
+
+    function removeRewardToken(address rt) public onlyGovernance {
+      uint256 i = getRewardTokenIndex(rt);
+      require(i != uint256(-1), "Reward token does not exists");
+      require(rewardTokens.length > 1, "Cannot remove the last reward token");
+      uint256 lastIndex = rewardTokens.length - 1;
+
+      // swap
+      rewardTokens[i] = rewardTokens[lastIndex];
+
+      // delete last element
+      rewardTokens.pop();
+    }
+
+    function rewardPoolBalance() internal view returns (uint256 bal) {
+        bal = IStakingRewardsWithPlatformToken(rewardPool()).balanceOf(address(this));
+    }
+
+    function exitRewardPool() internal {
+        uint256 bal = rewardPoolBalance();
+        if (bal == 0) {
+            return;
+        }
+
+        uint256 entireBalance = IERC20(underlying()).balanceOf(address(this));
+        // exit unstakes and claims any outstanding rewards (v-imUSD -> imUSD)
+        IStakingRewardsWithPlatformToken(rewardPool()).exit();
+
+        // withdraw from savings contract (imUSD -> mUSD)
+        uint256 entireImUSDBalance = IERC20(imUSD).balanceOf(address(this));
+        ISavingsContract(savingsContract()).redeemCredits(entireImUSDBalance);
+    }
+
+    function emergencyExitRewardPool() internal {
+        uint256 bal = rewardPoolBalance();
+        if (bal != 0) {
+            // unstake without claiming rewards
+            IStakingRewardsWithPlatformToken(rewardPool()).withdraw(bal);
+        }
+
+        // withdraw from savings contract (imUSD -> mUSD)
+        uint256 entireImUSDBalance = IERC20(imUSD).balanceOf(address(this));
+        if (entireImUSDBalance != 0) {
+            ISavingsContract(savingsContract()).redeemCredits(entireImUSDBalance);
+        }
+    }
+
+    function unsalvagableTokens(address token) public view returns (bool) {
+        return (token == rewardToken() || token == underlying());
+    }
+
+    function enterRewardPool() internal {
+        // deposit mUSD into savings contract to get imUSD
+        uint256 entireBalance = IERC20(underlying()).balanceOf(address(this));
+
+        IERC20(underlying()).safeApprove(savingsContract(), 0);
+        IERC20(underlying()).safeApprove(savingsContract(), entireBalance);
+        ISavingsContract(savingsContract()).depositSavings(entireBalance);
+
+        // stake imUSD into reward pool to get v-imUSD
+        uint256 entireImUSDBalance = IERC20(imUSD).balanceOf(address(this));
+        IERC20(imUSD).safeApprove(rewardPool(), 0);
+        IERC20(imUSD).safeApprove(rewardPool(), entireImUSDBalance);
+        IStakingRewardsWithPlatformToken(rewardPool()).stake(entireImUSDBalance);
+    }
+
+    /*
+    *   In case there are some issues discovered about the pool or underlying asset
+    *   Governance can exit the pool properly
+    *   The function is only used for emergency to exit the pool
+    */
+    function emergencyExit() public onlyGovernance {
+        emergencyExitRewardPool();
+        _setPausedInvesting(true);
+    }
+
+    /*
+    *   Resumes the ability to invest into the underlying reward pools
+    */
+
+    function continueInvesting() public onlyGovernance {
+        _setPausedInvesting(false);
+    }
+
+    function shouldSell() internal returns(bool) {
+        if(!sell()) {
+            return false;
+        }
+
+        // get total balance in all reward tokens. not perfect, but it's something
+        uint256 totalBalance = 0;
+        for(uint256 i = 0; i < rewardTokens.length; i++){
+            address token = rewardTokens[i];
+            uint256 rewardBalance = IERC20(token).balanceOf(address(this));
+            totalBalance = totalBalance.add(rewardBalance);
+        }
+
+        if (totalBalance < sellFloor()) {
+            // Profits can be disabled for possible simplified and rapid exit
+            emit ProfitsNotCollected(sell(), totalBalance < sellFloor());
+            return false;
+        }
+        
+        return true;
+    }
+
+
+    function swapViaBalancer(address from, address to, uint256 amount) internal {
+        //swap bal to weth on balancer
+        IBVault.SingleSwap memory singleSwap;
+        IBVault.SwapKind swapKind = IBVault.SwapKind.GIVEN_IN;
+
+        singleSwap.poolId = storedBalancerPoolIds[from][to];
+        singleSwap.kind = swapKind;
+        singleSwap.assetIn = IAsset(from);
+        singleSwap.assetOut = IAsset(to);
+        singleSwap.amount = amount;
+        singleSwap.userData = abi.encode(0);
+
+        IBVault.FundManagement memory funds;
+        funds.sender = address(this);
+        funds.fromInternalBalance = false;
+        funds.recipient = payable(address(this));
+        funds.toInternalBalance = false;
+
+        IERC20(from).safeApprove(balancerRouter, 0);
+        IERC20(from).safeApprove(balancerRouter, amount);
+
+        IBVault(balancerRouter).swap(singleSwap, funds, 1, block.timestamp);
+    }
+
+    function swapViaMStable(address from, address to, uint256 amount) internal {
+        IERC20(from).safeApprove(musd, 0);
+        IERC20(from).safeApprove(musd, amount);
+        if(to == musd) {
+            // we can mint
+            IMasset(musd).mint(
+                from, // input token
+                amount, // input quantity
+                1, // min output quantity (we can accept 1 as the minimum because this will be called only by a trusted worker)
+                address(this) // recipient
+            );
+        } else {
+            // other swaps currently not needed and not implemented!
+            return;
+        }
+    }
+
+    function swapViaIUniswap(address from, address to, uint256 amount, address routerAddress) internal {
+        IERC20(from).safeApprove(routerAddress, 0);
+        IERC20(from).safeApprove(routerAddress, amount);
+
+        address[] memory liquidationPath = new address[](2);
+        liquidationPath[0] = from;
+        liquidationPath[1] = to;
+
+        IUniswapV2Router02(routerAddress).swapExactTokensForTokens(
+            amount,
+             // we can accept 1 as the minimum because this will be called only by a trusted worker
+            1,
+            liquidationPath,
+            address(this),
+            block.timestamp
+        );
+    }
+
+    function swapViaDex(address from, address to, uint256 amount) internal {
+        if(storedLiquidationDexes[from][to] == quickDex) {
+            swapViaIUniswap(from, to, amount, quickswapRouterV2);
+        } else if(storedLiquidationDexes[from][to] == sushiDex) {
+            swapViaIUniswap(from, to, amount, sushiswapRouterV2);
+        } else if(storedLiquidationDexes[from][to] == balancerDex) {
+            swapViaBalancer(from, to, amount);
+        } else if(storedLiquidationDexes[from][to] == mstableDex) {
+            swapViaMStable(from, to, amount);
+        } else {
+            // no dex defined, this should not happen since it is also checked before
+            return;
+        }
+    }
+
+    function strategyRewardsToRewardToken() internal {
+        // swap rewards to WETH (rewardToken)
+        for(uint256 i = 0; i < rewardTokens.length; i++){
+            address token = rewardTokens[i];
+            uint256 rewardBalance = IERC20(token).balanceOf(address(this));
+            if (rewardBalance == 0 || storedLiquidationDexes[token][rewardToken()].length < 1) {
+                continue;
+            }
+
+            swapViaDex(token, rewardToken(), rewardBalance);
+        }
+    }
+
+    function rewardTokenToUnderlying() internal  {
+        // must first swap rewardToken to tradeable asset on mStable, such as DAI
+        uint256 rewardBalance = IERC20(rewardToken()).balanceOf(address(this));
+
+        if (rewardBalance == 0 || storedLiquidationDexes[rewardToken()][dai].length < 1) {
+            return;
+        }
+        swapViaDex(rewardToken(), dai, rewardBalance);
+
+        // swap DAI to underlying on mStable
+        uint256 daiBalance = IERC20(dai).balanceOf(address(this));
+        if (daiBalance == 0 || storedLiquidationDexes[dai][underlying()].length < 1) {
+            return;
+        }
+        swapViaDex(dai, underlying(), daiBalance);
+    }
+
+    function liquidateReward() internal {
+        if (!shouldSell()) {
+            return;
+        }
+
+        // MTA and WMATIC to WETH
+        strategyRewardsToRewardToken();
+
+        uint256 rewardBalance = IERC20(rewardToken()).balanceOf(address(this));
+        notifyProfitInRewardToken(rewardBalance);
+        uint256 remainingRewardBalance = IERC20(rewardToken()).balanceOf(address(this));
+
+        if (remainingRewardBalance == 0) {
+            return;
+        }
+
+        // WETH to underlying (WETH -> DAI -> mUSD)
+        rewardTokenToUnderlying();
+    }
+
+    /*
+    *   Stakes everything the strategy holds into the reward pool
+    */
+    function investAllUnderlying() internal onlyNotPausedInvesting {
+        // ensure there is any balance to invest
+        if(IERC20(underlying()).balanceOf(address(this)) > 0) {
+            enterRewardPool();
+        }
+    }
+
+    /*
+    *   Withdraws all the asset to the vault
+    */
+    function withdrawAllToVault() public restricted {
+        if (address(rewardPool()) != address(0)) {
+            // this also claims all oustanding rewards
+            exitRewardPool();
+        }
+        liquidateReward();
+        IERC20(underlying()).safeTransfer(vault(), IERC20(underlying()).balanceOf(address(this)));
+    }
+
+    /*
+    *   Withdraws all the asset to the vault
+    */
+    function withdrawToVault(uint256 amount) public restricted {
+        // Typically there wouldn't be any amount here
+        // however, it is possible because of the emergencyExit
+        uint256 entireBalance = IERC20(underlying()).balanceOf(address(this));
+
+        if(amount > entireBalance){
+            // While we have the check above, we still using SafeMath below
+            // for the peace of mind (in case something gets changed in between)
+            uint256 needToWithdraw = amount.sub(entireBalance);
+
+            // Note that we need to withdraw a certain amount in mUSD while invested is in imUSD (Credits with exchange rate)
+            // so we need to calculate accordingly (toWithraw must be the amount in credits that equals input amount in mUSD)
+            uint256 amountToWithdrawInCredits = ISavingsContract(savingsContract()).underlyingToCredits(needToWithdraw);
+            uint256 toWithdraw = Math.min(rewardPoolBalance(), amountToWithdrawInCredits);
+
+            // unstake (v-imUSD -> imUSD)
+            IStakingRewardsWithPlatformToken(rewardPool()).withdraw(toWithdraw);
+
+            // withdraw from savings contract (imUSD -> mUSD)
+            ISavingsContract(savingsContract()).redeemCredits(toWithdraw);
+        }
+
+        IERC20(underlying()).safeTransfer(vault(), amount);
+    }
+
+    /*
+    *   Note that we currently do not have a mechanism here to include the
+    *   amount of reward that is accrued.
+    */
+    function investedUnderlyingBalance() external view returns (uint256) {
+        uint256 underlyingBalance = IERC20(underlying()).balanceOf(address(this));
+        if (rewardPool() == address(0)) {
+            return underlyingBalance;
+        }
+
+
+        uint256 rewardPoolBalanceImUSD = rewardPoolBalance();
+
+        // reward pool balance is in imUSD which actual value in mUSD depends on an exchange rate set in the savings contract
+        uint256 rewardPoolBalanceInUnderlying = ISavingsContract(savingsContract()).creditsToUnderlying(rewardPoolBalanceImUSD);
+
+        // Adding the amount locked in the reward pool and the amount that is somehow in this contract
+        // both are in the units of "underlying"
+        // The second part is needed because there is the emergency exit mechanism
+        // which would break the assumption that all the funds are always inside of the reward pool
+        return rewardPoolBalanceInUnderlying.add(underlyingBalance);
+    }
+
+    /*
+    *   Governance or Controller can claim coins that are somehow transferred into the contract
+    *   Note that they cannot come in take away coins that are used and defined in the strategy itself
+    */
+    function salvage(address recipient, address token, uint256 amount) external onlyControllerOrGovernance {
+        // To make sure that governance cannot come in and take away the coins
+        require(!unsalvagableTokens(token), "token is defined as not salvagable");
+        IERC20(token).safeTransfer(recipient, amount);
+    }
+
+    /*
+    *   Get the reward, sell it in exchange for underlying, invest what you got.
+    *   It's not much, but it's honest work.
+    */
+    function doHardWork() external onlyNotPausedInvesting restricted {
+        // claims both the platformToken and the rewardsToken (MTA & WMATIC)
+        IStakingRewardsWithPlatformToken(rewardPool()).claimReward();
+        liquidateReward();
+        investAllUnderlying();
+    }
+
+    /**
+    * Can completely disable claiming rewards and selling. Good for emergency withdraw in the
+    * simplest possible way.
+    */
+    function setSell(bool s) public onlyGovernance {
+        _setSell(s);
+    }
+
+    /**
+    * Sets the minimum amount of earnings in any reward token needed to trigger a sale.
+    */
+    function setSellFloor(uint256 floor) public onlyGovernance {
+        _setSellFloor(floor);
+    }
+
+
+    function setBalancerPoolId(address from, address to, bytes32 poolId) public onlyGovernance {
+        storedBalancerPoolIds[from][to] = poolId;
+    }
+
+    function setLiquidationDex(address from, address to, bytes32 dex) public onlyGovernance {
+        storedLiquidationDexes[from][to] = dex;
+    }
+
+    function setSavingsContract(address savingsContract)  public onlyGovernance {
+        require(address(ISavingsContract(savingsContract).underlying()) == underlying(), 'underlying does not match savings contract underlying');
+        return setAddress(_SAVINGS_CONTRACT, savingsContract);
+    }
+
+    function savingsContract() public view returns (address) {
+        return getAddress(_SAVINGS_CONTRACT);
+    }
+
+    function finalizeUpgrade() external virtual onlyGovernance {
+        _finalizeUpgrade();
+    }
+}

--- a/contracts/strategies/mstable/MStableStrategy.sol
+++ b/contracts/strategies/mstable/MStableStrategy.sol
@@ -14,8 +14,6 @@ import "./interfaces/ISavingsContract.sol";
 import "./interfaces/IBVault.sol";
 import "./interfaces/IMasset.sol";
 
-import 'hardhat/console.sol';
-
 contract MStableStrategy is BaseUpgradeableStrategy {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;

--- a/contracts/strategies/mstable/MStableStrategyMainnet_mUSD.sol
+++ b/contracts/strategies/mstable/MStableStrategyMainnet_mUSD.sol
@@ -1,0 +1,79 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./MStableStrategy.sol";
+
+import 'hardhat/console.sol';
+
+contract MStableStrategyMainnet_mUSD is MStableStrategy {
+
+    address public mstable_musd_unused; // just a differentiator for the bytecode
+
+    constructor() public {}
+
+    function initializeStrategy(
+      address _storage,
+      address _vault
+    ) public initializer {
+        address savingsContract = address(0x5290Ad3d83476CA6A2b178Cd9727eE1EF72432af); // imUSD savings contract
+        address underlying = address(0xE840B73E5287865EEc17d250bFb1536704B43B21); // mUSD
+        address rewardPool = address(0x32aBa856Dc5fFd5A56Bcd182b13380e5C855aa29); // imUSD staking contract (v-imUSD Vault)
+        address mta = address(0xF501dd45a1198C2E1b5aEF5314A68B9006D842E0); // reward token 1 of strategy is MTA (rewardToken)
+        address wmatic = address(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270); // reward token 2 of strategy is WMATIC (platformToken)
+        address dai = address(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063); // needed for liquidation to underlying
+
+        address weth = address(0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619); // reward token for harvest fees after liquidation
+
+        bytes32 balancerDex = bytes32(0x9e73ce1e99df7d45bc513893badf42bc38069f1564ee511b0c8988f72f127b13);
+        bytes32 quickDex = bytes32(0x7bfa33731cff39bf8528ed70e5709ec0b799f5230ae0e1856a15d99aa053da30);
+        bytes32 mstableDex = bytes32(0x57a5a8ea4df7587ebb4c9aaa2bb3c9f9d459b4962f8b74c320c85916983e67db);
+        bytes32 balancerMtaPoolId = bytes32(0x614b5038611729ed49e0ded154d8a5d3af9d1d9e00010000000000000000001d);
+
+        MStableStrategy._initializeStrategy(
+          _storage,
+          underlying,
+          _vault,
+          rewardPool, // reward pool
+          weth // reward token
+        );
+
+        setSavingsContract(savingsContract);
+        
+        rewardTokens = [mta, wmatic];
+
+        // reward tokens of strategy (MTA, WMATIC) -> fee reward token (WETH)
+        storedLiquidationDexes[wmatic][weth] = quickDex;
+        storedLiquidationDexes[mta][weth] = balancerDex;
+        storedBalancerPoolIds[mta][weth] = balancerMtaPoolId;
+
+        // fee reward token (WETH) -> underlying (mUSD)
+        // Note: have to go through DAI to swap on mStable
+        storedLiquidationDexes[weth][dai] = quickDex;
+        storedLiquidationDexes[dai][underlying] = mstableDex;
+    }
+
+    function finalizeUpgrade() external override onlyGovernance {
+        _finalizeUpgrade();
+
+        address underlying = address(0xE840B73E5287865EEc17d250bFb1536704B43B21); // mUSD
+        address mta = address(0xF501dd45a1198C2E1b5aEF5314A68B9006D842E0); // reward token 1 of strategy is MTA (rewardToken)
+        address wmatic = address(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270); // reward token 2 of strategy is WMATIC (platformToken)
+        address dai = address(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063); // needed for liquidation to underlying
+        address weth = address(0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619); // reward token for harvest fees after liquidation
+
+        // reward tokens must be re-set manually
+        rewardTokens = new address[](0);
+
+        // Reset the liquidation paths - they need to be reset manually
+        // reward tokens of strategy (MTA, WMATIC) -> fee reward token (WETH)
+        storedLiquidationDexes[wmatic][weth] = bytes32(0);
+        storedLiquidationDexes[mta][weth] = bytes32(0);
+        storedBalancerPoolIds[mta][weth] = bytes32(0);
+
+        // fee reward token (WETH) -> underlying (mUSD)
+        // Note: have to go through DAI to swap on mStable
+        storedLiquidationDexes[weth][dai] = bytes32(0);
+        storedLiquidationDexes[dai][underlying] = bytes32(0);
+  }
+}

--- a/contracts/strategies/mstable/MStableStrategyMainnet_mUSD.sol
+++ b/contracts/strategies/mstable/MStableStrategyMainnet_mUSD.sol
@@ -4,8 +4,6 @@ pragma experimental ABIEncoderV2;
 
 import "./MStableStrategy.sol";
 
-import 'hardhat/console.sol';
-
 contract MStableStrategyMainnet_mUSD is MStableStrategy {
 
     address public mstable_musd_unused; // just a differentiator for the bytecode

--- a/contracts/strategies/mstable/interfaces/IBVault.sol
+++ b/contracts/strategies/mstable/interfaces/IBVault.sol
@@ -1,0 +1,557 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IAsset {
+}
+
+interface IBVault {
+    // Internal Balance
+    //
+    // Users can deposit tokens into the Vault, where they are allocated to their Internal Balance, and later
+    // transferred or withdrawn. It can also be used as a source of tokens when joining Pools, as a destination
+    // when exiting them, and as either when performing swaps. This usage of Internal Balance results in greatly reduced
+    // gas costs when compared to relying on plain ERC20 transfers, leading to large savings for frequent users.
+    //
+    // Internal Balance management features batching, which means a single contract call can be used to perform multiple
+    // operations of different kinds, with different senders and recipients, at once.
+
+    /**
+     * @dev Returns `user`'s Internal Balance for a set of tokens.
+     */
+    function getInternalBalance(address user, IERC20[] calldata tokens) external view returns (uint256[] memory);
+
+    /**
+     * @dev Performs a set of user balance operations, which involve Internal Balance (deposit, withdraw or transfer)
+     * and plain ERC20 transfers using the Vault's allowance. This last feature is particularly useful for relayers, as
+     * it lets integrators reuse a user's Vault allowance.
+     *
+     * For each operation, if the caller is not `sender`, it must be an authorized relayer for them.
+     */
+    function manageUserBalance(UserBalanceOp[] calldata ops) external payable;
+
+    /**
+     * @dev Data for `manageUserBalance` operations, which include the possibility for ETH to be sent and received
+     without manual WETH wrapping or unwrapping.
+     */
+    struct UserBalanceOp {
+        UserBalanceOpKind kind;
+        IAsset asset;
+        uint256 amount;
+        address sender;
+        address payable recipient;
+    }
+
+    // There are four possible operations in `manageUserBalance`:
+    //
+    // - DEPOSIT_INTERNAL
+    // Increases the Internal Balance of the `recipient` account by transferring tokens from the corresponding
+    // `sender`. The sender must have allowed the Vault to use their tokens via `IERC20.approve()`.
+    //
+    // ETH can be used by passing the ETH sentinel value as the asset and forwarding ETH in the call: it will be wrapped
+    // and deposited as WETH. Any ETH amount remaining will be sent back to the caller (not the sender, which is
+    // relevant for relayers).
+    //
+    // Emits an `InternalBalanceChanged` event.
+    //
+    //
+    // - WITHDRAW_INTERNAL
+    // Decreases the Internal Balance of the `sender` account by transferring tokens to the `recipient`.
+    //
+    // ETH can be used by passing the ETH sentinel value as the asset. This will deduct WETH instead, unwrap it and send
+    // it to the recipient as ETH.
+    //
+    // Emits an `InternalBalanceChanged` event.
+    //
+    //
+    // - TRANSFER_INTERNAL
+    // Transfers tokens from the Internal Balance of the `sender` account to the Internal Balance of `recipient`.
+    //
+    // Reverts if the ETH sentinel value is passed.
+    //
+    // Emits an `InternalBalanceChanged` event.
+    //
+    //
+    // - TRANSFER_EXTERNAL
+    // Transfers tokens from `sender` to `recipient`, using the Vault's ERC20 allowance. This is typically used by
+    // relayers, as it lets them reuse a user's Vault allowance.
+    //
+    // Reverts if the ETH sentinel value is passed.
+    //
+    // Emits an `ExternalBalanceTransfer` event.
+
+    enum UserBalanceOpKind { DEPOSIT_INTERNAL, WITHDRAW_INTERNAL, TRANSFER_INTERNAL, TRANSFER_EXTERNAL }
+
+    /**
+     * @dev Emitted when a user's Internal Balance changes, either from calls to `manageUserBalance`, or through
+     * interacting with Pools using Internal Balance.
+     *
+     * Because Internal Balance works exclusively with ERC20 tokens, ETH deposits and withdrawals will use the WETH
+     * address.
+     */
+    event InternalBalanceChanged(address indexed user, IERC20 indexed token, int256 delta);
+
+    /**
+     * @dev Emitted when a user's Vault ERC20 allowance is used by the Vault to transfer tokens to an external account.
+     */
+    event ExternalBalanceTransfer(IERC20 indexed token, address indexed sender, address recipient, uint256 amount);
+
+    // Pools
+    //
+    // There are three specialization settings for Pools, which allow for cheaper swaps at the cost of reduced
+    // functionality:
+    //
+    //  - General: no specialization, suited for all Pools. IGeneralPool is used for swap request callbacks, passing the
+    // balance of all tokens in the Pool. These Pools have the largest swap costs (because of the extra storage reads),
+    // which increase with the number of registered tokens.
+    //
+    //  - Minimal Swap Info: IMinimalSwapInfoPool is used instead of IGeneralPool, which saves gas by only passing the
+    // balance of the two tokens involved in the swap. This is suitable for some pricing algorithms, like the weighted
+    // constant product one popularized by Balancer V1. Swap costs are smaller compared to general Pools, and are
+    // independent of the number of registered tokens.
+    //
+    //  - Two Token: only allows two tokens to be registered. This achieves the lowest possible swap gas cost. Like
+    // minimal swap info Pools, these are called via IMinimalSwapInfoPool.
+
+    enum PoolSpecialization { GENERAL, MINIMAL_SWAP_INFO, TWO_TOKEN }
+
+    /**
+     * @dev Registers the caller account as a Pool with a given specialization setting. Returns the Pool's ID, which
+     * is used in all Pool-related functions. Pools cannot be deregistered, nor can the Pool's specialization be
+     * changed.
+     *
+     * The caller is expected to be a smart contract that implements either `IGeneralPool` or `IMinimalSwapInfoPool`,
+     * depending on the chosen specialization setting. This contract is known as the Pool's contract.
+     *
+     * Note that the same contract may register itself as multiple Pools with unique Pool IDs, or in other words,
+     * multiple Pools may share the same contract.
+     *
+     * Emits a `PoolRegistered` event.
+     */
+    function registerPool(PoolSpecialization specialization) external returns (bytes32);
+
+    /**
+     * @dev Emitted when a Pool is registered by calling `registerPool`.
+     */
+    event PoolRegistered(bytes32 indexed poolId, address indexed poolAddress, PoolSpecialization specialization);
+
+    /**
+     * @dev Returns a Pool's contract address and specialization setting.
+     */
+    function getPool(bytes32 poolId) external view returns (address, PoolSpecialization);
+
+    /**
+     * @dev Registers `tokens` for the `poolId` Pool. Must be called by the Pool's contract.
+     *
+     * Pools can only interact with tokens they have registered. Users join a Pool by transferring registered tokens,
+     * exit by receiving registered tokens, and can only swap registered tokens.
+     *
+     * Each token can only be registered once. For Pools with the Two Token specialization, `tokens` must have a length
+     * of two, that is, both tokens must be registered in the same `registerTokens` call, and they must be sorted in
+     * ascending order.
+     *
+     * The `tokens` and `assetManagers` arrays must have the same length, and each entry in these indicates the Asset
+     * Manager for the corresponding token. Asset Managers can manage a Pool's tokens via `managePoolBalance`,
+     * depositing and withdrawing them directly, and can even set their balance to arbitrary amounts. They are therefore
+     * expected to be highly secured smart contracts with sound design principles, and the decision to register an
+     * Asset Manager should not be made lightly.
+     *
+     * Pools can choose not to assign an Asset Manager to a given token by passing in the zero address. Once an Asset
+     * Manager is set, it cannot be changed except by deregistering the associated token and registering again with a
+     * different Asset Manager.
+     *
+     * Emits a `TokensRegistered` event.
+     */
+    function registerTokens(
+        bytes32 poolId,
+        IERC20[] calldata tokens,
+        address[] calldata assetManagers
+    ) external;
+
+    /**
+     * @dev Emitted when a Pool registers tokens by calling `registerTokens`.
+     */
+    event TokensRegistered(bytes32 indexed poolId, IERC20[] tokens, address[] assetManagers);
+
+    /**
+     * @dev Deregisters `tokens` for the `poolId` Pool. Must be called by the Pool's contract.
+     *
+     * Only registered tokens (via `registerTokens`) can be deregistered. Additionally, they must have zero total
+     * balance. For Pools with the Two Token specialization, `tokens` must have a length of two, that is, both tokens
+     * must be deregistered in the same `deregisterTokens` call.
+     *
+     * A deregistered token can be re-registered later on, possibly with a different Asset Manager.
+     *
+     * Emits a `TokensDeregistered` event.
+     */
+    function deregisterTokens(bytes32 poolId, IERC20[] calldata tokens) external;
+
+    /**
+     * @dev Emitted when a Pool deregisters tokens by calling `deregisterTokens`.
+     */
+    event TokensDeregistered(bytes32 indexed poolId, IERC20[] tokens);
+
+    /**
+     * @dev Returns detailed information for a Pool's registered token.
+     *
+     * `cash` is the number of tokens the Vault currently holds for the Pool. `managed` is the number of tokens
+     * withdrawn and held outside the Vault by the Pool's token Asset Manager. The Pool's total balance for `token`
+     * equals the sum of `cash` and `managed`.
+     *
+     * Internally, `cash` and `managed` are stored using 112 bits. No action can ever cause a Pool's token `cash`,
+     * `managed` or `total` balance to be greater than 2^112 - 1.
+     *
+     * `lastChangeBlock` is the number of the block in which `token`'s total balance was last modified (via either a
+     * join, exit, swap, or Asset Manager update). This value is useful to avoid so-called 'sandwich attacks', for
+     * example when developing price oracles. A change of zero (e.g. caused by a swap with amount zero) is considered a
+     * change for this purpose, and will update `lastChangeBlock`.
+     *
+     * `assetManager` is the Pool's token Asset Manager.
+     */
+    function getPoolTokenInfo(bytes32 poolId, IERC20 token)
+        external
+        view
+        returns (
+            uint256 cash,
+            uint256 managed,
+            uint256 lastChangeBlock,
+            address assetManager
+        );
+
+    /**
+     * @dev Returns a Pool's registered tokens, the total balance for each, and the latest block when *any* of
+     * the tokens' `balances` changed.
+     *
+     * The order of the `tokens` array is the same order that will be used in `joinPool`, `exitPool`, as well as in all
+     * Pool hooks (where applicable). Calls to `registerTokens` and `deregisterTokens` may change this order.
+     *
+     * If a Pool only registers tokens once, and these are sorted in ascending order, they will be stored in the same
+     * order as passed to `registerTokens`.
+     *
+     * Total balances include both tokens held by the Vault and those withdrawn by the Pool's Asset Managers. These are
+     * the amounts used by joins, exits and swaps. For a detailed breakdown of token balances, use `getPoolTokenInfo`
+     * instead.
+     */
+    function getPoolTokens(bytes32 poolId)
+        external
+        view
+        returns (
+            IERC20[] memory tokens,
+            uint256[] memory balances,
+            uint256 lastChangeBlock
+        );
+
+    /**
+     * @dev Called by users to join a Pool, which transfers tokens from `sender` into the Pool's balance. This will
+     * trigger custom Pool behavior, which will typically grant something in return to `recipient` - often tokenized
+     * Pool shares.
+     *
+     * If the caller is not `sender`, it must be an authorized relayer for them.
+     *
+     * The `assets` and `maxAmountsIn` arrays must have the same length, and each entry indicates the maximum amount
+     * to send for each asset. The amounts to send are decided by the Pool and not the Vault: it just enforces
+     * these maximums.
+     *
+     * If joining a Pool that holds WETH, it is possible to send ETH directly: the Vault will do the wrapping. To enable
+     * this mechanism, the IAsset sentinel value (the zero address) must be passed in the `assets` array instead of the
+     * WETH address. Note that it is not possible to combine ETH and WETH in the same join. Any excess ETH will be sent
+     * back to the caller (not the sender, which is important for relayers).
+     *
+     * `assets` must have the same length and order as the array returned by `getPoolTokens`. This prevents issues when
+     * interacting with Pools that register and deregister tokens frequently. If sending ETH however, the array must be
+     * sorted *before* replacing the WETH address with the ETH sentinel value (the zero address), which means the final
+     * `assets` array might not be sorted. Pools with no registered tokens cannot be joined.
+     *
+     * If `fromInternalBalance` is true, the caller's Internal Balance will be preferred: ERC20 transfers will only
+     * be made for the difference between the requested amount and Internal Balance (if any). Note that ETH cannot be
+     * withdrawn from Internal Balance: attempting to do so will trigger a revert.
+     *
+     * This causes the Vault to call the `IBasePool.onJoinPool` hook on the Pool's contract, where Pools implement
+     * their own custom logic. This typically requires additional information from the user (such as the expected number
+     * of Pool shares). This can be encoded in the `userData` argument, which is ignored by the Vault and passed
+     * directly to the Pool's contract, as is `recipient`.
+     *
+     * Emits a `PoolBalanceChanged` event.
+     */
+    function joinPool(
+        bytes32 poolId,
+        address sender,
+        address recipient,
+        JoinPoolRequest calldata request
+    ) external payable;
+
+    enum JoinKind { INIT, EXACT_TOKENS_IN_FOR_BPT_OUT, TOKEN_IN_FOR_EXACT_BPT_OUT }
+    enum ExitKind { EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, EXACT_BPT_IN_FOR_TOKENS_OUT, BPT_IN_FOR_EXACT_TOKENS_OUT }
+
+    struct JoinPoolRequest {
+        IAsset[] assets;
+        uint256[] maxAmountsIn;
+        bytes userData;
+        bool fromInternalBalance;
+    }
+
+    /**
+     * @dev Called by users to exit a Pool, which transfers tokens from the Pool's balance to `recipient`. This will
+     * trigger custom Pool behavior, which will typically ask for something in return from `sender` - often tokenized
+     * Pool shares. The amount of tokens that can be withdrawn is limited by the Pool's `cash` balance (see
+     * `getPoolTokenInfo`).
+     *
+     * If the caller is not `sender`, it must be an authorized relayer for them.
+     *
+     * The `tokens` and `minAmountsOut` arrays must have the same length, and each entry in these indicates the minimum
+     * token amount to receive for each token contract. The amounts to send are decided by the Pool and not the Vault:
+     * it just enforces these minimums.
+     *
+     * If exiting a Pool that holds WETH, it is possible to receive ETH directly: the Vault will do the unwrapping. To
+     * enable this mechanism, the IAsset sentinel value (the zero address) must be passed in the `assets` array instead
+     * of the WETH address. Note that it is not possible to combine ETH and WETH in the same exit.
+     *
+     * `assets` must have the same length and order as the array returned by `getPoolTokens`. This prevents issues when
+     * interacting with Pools that register and deregister tokens frequently. If receiving ETH however, the array must
+     * be sorted *before* replacing the WETH address with the ETH sentinel value (the zero address), which means the
+     * final `assets` array might not be sorted. Pools with no registered tokens cannot be exited.
+     *
+     * If `toInternalBalance` is true, the tokens will be deposited to `recipient`'s Internal Balance. Otherwise,
+     * an ERC20 transfer will be performed. Note that ETH cannot be deposited to Internal Balance: attempting to
+     * do so will trigger a revert.
+     *
+     * `minAmountsOut` is the minimum amount of tokens the user expects to get out of the Pool, for each token in the
+     * `tokens` array. This array must match the Pool's registered tokens.
+     *
+     * This causes the Vault to call the `IBasePool.onExitPool` hook on the Pool's contract, where Pools implement
+     * their own custom logic. This typically requires additional information from the user (such as the expected number
+     * of Pool shares to return). This can be encoded in the `userData` argument, which is ignored by the Vault and
+     * passed directly to the Pool's contract.
+     *
+     * Emits a `PoolBalanceChanged` event.
+     */
+    function exitPool(
+        bytes32 poolId,
+        address sender,
+        address payable recipient,
+        ExitPoolRequest calldata request
+    ) external;
+
+    struct ExitPoolRequest {
+        IAsset[] assets;
+        uint256[] minAmountsOut;
+        bytes userData;
+        bool toInternalBalance;
+    }
+
+    /**
+     * @dev Emitted when a user joins or exits a Pool by calling `joinPool` or `exitPool`, respectively.
+     */
+    event PoolBalanceChanged(
+        bytes32 indexed poolId,
+        address indexed liquidityProvider,
+        IERC20[] tokens,
+        int256[] deltas,
+        uint256[] protocolFeeAmounts
+    );
+
+    enum PoolBalanceChangeKind { JOIN, EXIT }
+
+    // Swaps
+    //
+    // Users can swap tokens with Pools by calling the `swap` and `batchSwap` functions. To do this,
+    // they need not trust Pool contracts in any way: all security checks are made by the Vault. They must however be
+    // aware of the Pools' pricing algorithms in order to estimate the prices Pools will quote.
+    //
+    // The `swap` function executes a single swap, while `batchSwap` can perform multiple swaps in sequence.
+    // In each individual swap, tokens of one kind are sent from the sender to the Pool (this is the 'token in'),
+    // and tokens of another kind are sent from the Pool to the recipient in exchange (this is the 'token out').
+    // More complex swaps, such as one token in to multiple tokens out can be achieved by batching together
+    // individual swaps.
+    //
+    // There are two swap kinds:
+    //  - 'given in' swaps, where the amount of tokens in (sent to the Pool) is known, and the Pool determines (via the
+    // `onSwap` hook) the amount of tokens out (to send to the recipient).
+    //  - 'given out' swaps, where the amount of tokens out (received from the Pool) is known, and the Pool determines
+    // (via the `onSwap` hook) the amount of tokens in (to receive from the sender).
+    //
+    // Additionally, it is possible to chain swaps using a placeholder input amount, which the Vault replaces with
+    // the calculated output of the previous swap. If the previous swap was 'given in', this will be the calculated
+    // tokenOut amount. If the previous swap was 'given out', it will use the calculated tokenIn amount. These extended
+    // swaps are known as 'multihop' swaps, since they 'hop' through a number of intermediate tokens before arriving at
+    // the final intended token.
+    //
+    // In all cases, tokens are only transferred in and out of the Vault (or withdrawn from and deposited into Internal
+    // Balance) after all individual swaps have been completed, and the net token balance change computed. This makes
+    // certain swap patterns, such as multihops, or swaps that interact with the same token pair in multiple Pools, cost
+    // much less gas than they would otherwise.
+    //
+    // It also means that under certain conditions it is possible to perform arbitrage by swapping with multiple
+    // Pools in a way that results in net token movement out of the Vault (profit), with no tokens being sent in (only
+    // updating the Pool's internal accounting).
+    //
+    // To protect users from front-running or the market changing rapidly, they supply a list of 'limits' for each token
+    // involved in the swap, where either the maximum number of tokens to send (by passing a positive value) or the
+    // minimum amount of tokens to receive (by passing a negative value) is specified.
+    //
+    // Additionally, a 'deadline' timestamp can also be provided, forcing the swap to fail if it occurs after
+    // this point in time (e.g. if the transaction failed to be included in a block promptly).
+    //
+    // If interacting with Pools that hold WETH, it is possible to both send and receive ETH directly: the Vault will do
+    // the wrapping and unwrapping. To enable this mechanism, the IAsset sentinel value (the zero address) must be
+    // passed in the `assets` array instead of the WETH address. Note that it is possible to combine ETH and WETH in the
+    // same swap. Any excess ETH will be sent back to the caller (not the sender, which is relevant for relayers).
+    //
+    // Finally, Internal Balance can be used when either sending or receiving tokens.
+
+    enum SwapKind { GIVEN_IN, GIVEN_OUT }
+
+    /**
+     * @dev Performs a swap with a single Pool.
+     *
+     * If the swap is 'given in' (the number of tokens to send to the Pool is known), it returns the amount of tokens
+     * taken from the Pool, which must be greater than or equal to `limit`.
+     *
+     * If the swap is 'given out' (the number of tokens to take from the Pool is known), it returns the amount of tokens
+     * sent to the Pool, which must be less than or equal to `limit`.
+     *
+     * Internal Balance usage and the recipient are determined by the `funds` struct.
+     *
+     * Emits a `Swap` event.
+     */
+    function swap(
+        SingleSwap calldata singleSwap,
+        FundManagement calldata funds,
+        uint256 limit,
+        uint256 deadline
+    ) external payable returns (uint256);
+
+    /**
+     * @dev Data for a single swap executed by `swap`. `amount` is either `amountIn` or `amountOut` depending on
+     * the `kind` value.
+     *
+     * `assetIn` and `assetOut` are either token addresses, or the IAsset sentinel value for ETH (the zero address).
+     * Note that Pools never interact with ETH directly: it will be wrapped to or unwrapped from WETH by the Vault.
+     *
+     * The `userData` field is ignored by the Vault, but forwarded to the Pool in the `onSwap` hook, and may be
+     * used to extend swap behavior.
+     */
+    struct SingleSwap {
+        bytes32 poolId;
+        SwapKind kind;
+        IAsset assetIn;
+        IAsset assetOut;
+        uint256 amount;
+        bytes userData;
+    }
+
+    /**
+     * @dev Performs a series of swaps with one or multiple Pools. In each individual swap, the caller determines either
+     * the amount of tokens sent to or received from the Pool, depending on the `kind` value.
+     *
+     * Returns an array with the net Vault asset balance deltas. Positive amounts represent tokens (or ETH) sent to the
+     * Vault, and negative amounts represent tokens (or ETH) sent by the Vault. Each delta corresponds to the asset at
+     * the same index in the `assets` array.
+     *
+     * Swaps are executed sequentially, in the order specified by the `swaps` array. Each array element describes a
+     * Pool, the token to be sent to this Pool, the token to receive from it, and an amount that is either `amountIn` or
+     * `amountOut` depending on the swap kind.
+     *
+     * Multihop swaps can be executed by passing an `amount` value of zero for a swap. This will cause the amount in/out
+     * of the previous swap to be used as the amount in for the current one. In a 'given in' swap, 'tokenIn' must equal
+     * the previous swap's `tokenOut`. For a 'given out' swap, `tokenOut` must equal the previous swap's `tokenIn`.
+     *
+     * The `assets` array contains the addresses of all assets involved in the swaps. These are either token addresses,
+     * or the IAsset sentinel value for ETH (the zero address). Each entry in the `swaps` array specifies tokens in and
+     * out by referencing an index in `assets`. Note that Pools never interact with ETH directly: it will be wrapped to
+     * or unwrapped from WETH by the Vault.
+     *
+     * Internal Balance usage, sender, and recipient are determined by the `funds` struct. The `limits` array specifies
+     * the minimum or maximum amount of each token the vault is allowed to transfer.
+     *
+     * `batchSwap` can be used to make a single swap, like `swap` does, but doing so requires more gas than the
+     * equivalent `swap` call.
+     *
+     * Emits `Swap` events.
+     */
+    function batchSwap(
+        SwapKind kind,
+        BatchSwapStep[] calldata swaps,
+        IAsset[] calldata assets,
+        FundManagement calldata funds,
+        int256[] calldata limits,
+        uint256 deadline
+    ) external payable returns (int256[] memory);
+
+    /**
+     * @dev Data for each individual swap executed by `batchSwap`. The asset in and out fields are indexes into the
+     * `assets` array passed to that function, and ETH assets are converted to WETH.
+     *
+     * If `amount` is zero, the multihop mechanism is used to determine the actual amount based on the amount in/out
+     * from the previous swap, depending on the swap kind.
+     *
+     * The `userData` field is ignored by the Vault, but forwarded to the Pool in the `onSwap` hook, and may be
+     * used to extend swap behavior.
+     */
+    struct BatchSwapStep {
+        bytes32 poolId;
+        uint256 assetInIndex;
+        uint256 assetOutIndex;
+        uint256 amount;
+        bytes userData;
+    }
+
+    /**
+     * @dev Emitted for each individual swap performed by `swap` or `batchSwap`.
+     */
+    event Swap(
+        bytes32 indexed poolId,
+        IERC20 indexed tokenIn,
+        IERC20 indexed tokenOut,
+        uint256 amountIn,
+        uint256 amountOut
+    );
+
+    /**
+     * @dev All tokens in a swap are either sent from the `sender` account to the Vault, or from the Vault to the
+     * `recipient` account.
+     *
+     * If the caller is not `sender`, it must be an authorized relayer for them.
+     *
+     * If `fromInternalBalance` is true, the `sender`'s Internal Balance will be preferred, performing an ERC20
+     * transfer for the difference between the requested amount and the User's Internal Balance (if any). The `sender`
+     * must have allowed the Vault to use their tokens via `IERC20.approve()`. This matches the behavior of
+     * `joinPool`.
+     *
+     * If `toInternalBalance` is true, tokens will be deposited to `recipient`'s internal balance instead of
+     * transferred. This matches the behavior of `exitPool`.
+     *
+     * Note that ETH cannot be deposited to or withdrawn from Internal Balance: attempting to do so will trigger a
+     * revert.
+     */
+    struct FundManagement {
+        address sender;
+        bool fromInternalBalance;
+        address payable recipient;
+        bool toInternalBalance;
+    }
+
+    /**
+     * @dev Simulates a call to `batchSwap`, returning an array of Vault asset deltas. Calls to `swap` cannot be
+     * simulated directly, but an equivalent `batchSwap` call can and will yield the exact same result.
+     *
+     * Each element in the array corresponds to the asset at the same index, and indicates the number of tokens (or ETH)
+     * the Vault would take from the sender (if positive) or send to the recipient (if negative). The arguments it
+     * receives are the same that an equivalent `batchSwap` call would receive.
+     *
+     * Unlike `batchSwap`, this function performs no checks on the sender or recipient field in the `funds` struct.
+     * This makes it suitable to be called by off-chain applications via eth_call without needing to hold tokens,
+     * approve them for the Vault, or even know a user's address.
+     *
+     * Note that this function is not 'view' (due to implementation details): the client code must explicitly execute
+     * eth_call instead of eth_sendTransaction.
+     */
+    function queryBatchSwap(
+        SwapKind kind,
+        BatchSwapStep[] calldata swaps,
+        IAsset[] calldata assets,
+        FundManagement calldata funds
+    ) external returns (int256[] memory assetDeltas);
+}

--- a/contracts/strategies/mstable/interfaces/IMasset.sol
+++ b/contracts/strategies/mstable/interfaces/IMasset.sol
@@ -1,0 +1,101 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+interface IMasset {
+    // Mint
+    function mint(
+        address _input,
+        uint256 _inputQuantity,
+        uint256 _minOutputQuantity,
+        address _recipient
+    ) external returns (uint256 mintOutput);
+
+    function mintMulti(
+        address[] calldata _inputs,
+        uint256[] calldata _inputQuantities,
+        uint256 _minOutputQuantity,
+        address _recipient
+    ) external returns (uint256 mintOutput);
+
+    function getMintOutput(address _input, uint256 _inputQuantity)
+        external
+        view
+        returns (uint256 mintOutput);
+
+    function getMintMultiOutput(address[] calldata _inputs, uint256[] calldata _inputQuantities)
+        external
+        view
+        returns (uint256 mintOutput);
+
+    // Swaps
+    function swap(
+        address _input,
+        address _output,
+        uint256 _inputQuantity,
+        uint256 _minOutputQuantity,
+        address _recipient
+    ) external returns (uint256 swapOutput);
+
+    function getSwapOutput(
+        address _input,
+        address _output,
+        uint256 _inputQuantity
+    ) external view returns (uint256 swapOutput);
+
+    // Redemption
+    function redeem(
+        address _output,
+        uint256 _mAssetQuantity,
+        uint256 _minOutputQuantity,
+        address _recipient
+    ) external returns (uint256 outputQuantity);
+
+    function redeemMasset(
+        uint256 _mAssetQuantity,
+        uint256[] calldata _minOutputQuantities,
+        address _recipient
+    ) external returns (uint256[] memory outputQuantities);
+
+    function redeemExactBassets(
+        address[] calldata _outputs,
+        uint256[] calldata _outputQuantities,
+        uint256 _maxMassetQuantity,
+        address _recipient
+    ) external returns (uint256 mAssetRedeemed);
+
+    function getRedeemOutput(address _output, uint256 _mAssetQuantity)
+        external
+        view
+    
+        returns (uint256 bAssetOutput);
+
+    function getRedeemExactBassetsOutput(
+        address[] calldata _outputs,
+        uint256[] calldata _outputQuantities
+    ) external view returns (uint256 mAssetAmount);
+
+    // Views
+    function getBasket() external view returns (bool, bool);
+
+    function bAssetIndexes(address) external view returns (uint8);
+
+    function getPrice() external view returns (uint256 price, uint256 k);
+
+    // SavingsManager
+    function collectInterest() external returns (uint256 swapFeesGained, uint256 newSupply);
+
+    function collectPlatformInterest()
+        external
+    
+        returns (uint256 mintAmount, uint256 newSupply);
+
+    // Admin
+    function setCacheSize(uint256 _cacheSize) external;
+
+    function setFees(uint256 _swapFee, uint256 _redemptionFee) external;
+
+    function setTransferFeesFlag(address _bAsset, bool _flag) external;
+
+    function migrateBassets(address[] calldata _bAssets, address _newIntegration) external;
+}

--- a/contracts/strategies/mstable/interfaces/ISavingsContract.sol
+++ b/contracts/strategies/mstable/interfaces/ISavingsContract.sol
@@ -1,0 +1,69 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ISavingsContract {
+    function creditBalances(address) external view returns (uint256); // V1 & V2 (use balanceOf)
+
+    /**
+     * @dev Deposit the senders savings to the vault, and credit them internally with "credits".
+     *      Credit amount is calculated as a ratio of deposit amount and exchange rate:
+     *                    credits = underlying / exchangeRate
+     *      We will first update the internal exchange rate by collecting any interest generated on the underlying.
+     * @param _amount      Units of underlying to deposit into savings vault
+     */
+    function depositSavings(uint256 _amount) external returns (uint256 creditsIssued); // V1 & V2
+
+
+    /**
+     * @dev Deposit the senders savings to the vault, and credit them internally with "credits".
+     *      Credit amount is calculated as a ratio of deposit amount and exchange rate:
+     *                    credits = underlying / exchangeRate
+     *      We will first update the internal exchange rate by collecting any interest generated on the underlying.
+     * @param _amount      Units of underlying to deposit into savings vault
+     * @param _beneficiary     Immediately transfer the imUSD token to this beneficiary address
+     */
+    function depositSavings(uint256 _amount, address _beneficiary)
+        external
+        returns (uint256 creditsIssued); // V2
+
+    /**
+     * @dev Redeem specific number of the senders "credits" in exchange for underlying.
+     *      Payout amount is calculated as a ratio of credits and exchange rate:
+     *                    payout = credits * exchangeRate
+     * @param _amount         Amount of credits to redeem
+     */
+    function redeemCredits(uint256 _amount) external returns (uint256 underlyingReturned); // V2
+    
+    /**
+     * @dev Redeem credits into a specific amount of underlying.
+     *      Credits needed to burn is calculated using:
+     *                    credits = underlying / exchangeRate
+     * @param _amount     Amount of underlying to redeem
+     */
+    function redeemUnderlying(uint256 _amount) external returns (uint256 creditsBurned); // V2
+
+    function exchangeRate() external view returns (uint256); // V1 & V2
+    
+    /**
+     * @dev Returns the underlying balance of a given user
+     * @param _user     Address of the user to check
+     */
+    function balanceOfUnderlying(address _user) external view returns (uint256 underlying); // V2
+
+    /**
+     * @dev Converts a given underlying amount into credits
+     * @param _underlying  Units of underlying
+     */
+    function underlyingToCredits(uint256 _underlying) external view returns (uint256 credits); // V2
+
+    /**
+     * @dev Converts a given credit amount into underlying
+     * @param _credits  Units of credits
+     */
+    function creditsToUnderlying(uint256 _credits) external view returns (uint256 underlying); // V2
+
+    function underlying() external view returns (IERC20 underlyingMasset); // V2
+}

--- a/contracts/strategies/mstable/interfaces/IStakingRewardsWithPlatformToken.sol
+++ b/contracts/strategies/mstable/interfaces/IStakingRewardsWithPlatformToken.sol
@@ -1,0 +1,72 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IStakingRewardsWithPlatformToken {
+    /**
+     * @dev Stakes a given amount of the StakingToken for the sender
+     * @param _amount Units of StakingToken
+     */
+    function stake(uint256 _amount) external;
+
+    /**
+     * @dev Stakes a given amount of the StakingToken for a given beneficiary
+     * @param _beneficiary Staked tokens are credited to this address
+     * @param _amount      Units of StakingToken
+     */
+    function stake(address _beneficiary, uint256 _amount) external;
+
+    /**
+     * @dev Withdraws stake from pool and claims any rewards
+     */
+    function exit() external;
+
+    /**
+     * @dev Withdraws given stake amount from the pool
+     * @param _amount Units of the staked token to withdraw
+     */
+    function withdraw(uint256 _amount) external;
+
+    /**
+     * @dev Claims outstanding rewards (both platform and native) for the sender.
+     * First updates outstanding reward allocation and then transfers.
+     */
+    function claimReward() external;
+
+    /**
+     * @dev Claims outstanding rewards for the sender. Only the native
+     * rewards token, and not the platform rewards
+     */
+    function claimRewardOnly() external;
+
+    /**
+     * @dev Gets the RewardsToken
+     */
+    function getRewardToken() external view returns (IERC20);
+
+     /**
+     * @dev Gets the PlatformToken
+     */
+    function getPlatformToken() external view returns (IERC20);
+
+    /**
+     * @dev Calculates the amount of unclaimed rewards a user has earned
+     * @return 'Reward' per staked token  (rewardToken, platformToken)
+     */
+    function rewardPerToken() external view returns (uint256, uint256);
+
+    /**
+     * @dev Calculates the amount of unclaimed rewards a user has earned
+     * @param _account User address
+     * @return Total reward amount earned (rewardToken, platformToken)
+     */
+    function earned(address _account) external view returns (uint256, uint256);
+
+    /**
+     * @dev Get the balance of a given account
+     * @param _account User for which to retrieve balance
+     */
+    function balanceOf(address _account) external view returns (uint256);
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -22,6 +22,7 @@ module.exports = {
       },
       forking: {
         url: `https://polygon-mainnet.g.alchemy.com/v2/${secret.alchemyKey}`,
+        blockNumber: 20604046, // <-- edit here
       },
     }
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chai": "^4.2.0",
     "dotenv": "^8.2.0",
     "ethers": "^5.0.26",
-    "hardhat": "^2.0.6",
+    "hardhat": "^2.6.7",
     "hardhat-deploy": "^0.7.0-beta.44",
     "hardhat-deploy-ethers": "^0.3.0-beta.7",
     "hardhat-spdx-license-identifier": "^2.0.3",

--- a/test/mstable/mstable-musd.js
+++ b/test/mstable/mstable-musd.js
@@ -1,0 +1,123 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+  swapMaticToToken,
+  addLiquidity,
+  wrapMATIC
+} = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("IERC20");
+
+const Strategy = artifacts.require("MStableStrategyMainnet_mUSD");
+
+// Developed and tested at blockNumber 20604046
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Polygon Mainnet mStable mUSD", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x0C2eF8a1b3Bc00Bf676053732F31a67ebbA5bD81";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xE840B73E5287865EEc17d250bFb1536704B43B21");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 1e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000");
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    await strategy.setSellFloor(1, {from:governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      // The rewards are time based and Hardhat propagates the chain with a block time of 16s
+      // So we have 225 blocks per hour, 2700 blocks per 12 hours.
+      let hours = 10;
+      let blocksPerHour = 2700;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/225))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/225))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+    });
+  });
+});


### PR DESCRIPTION
Implements the first mStable strategy for the mUSD vault, using the staking of mStable on poylgon which is without vesting and instant withdrawal.

I'd also like to propose to add the blockNumber to hardhat config and update hardhad to the latest version since I ran into a problem with the older version and we had another builder running into some issue with the older version recently discussed on discord. Both times the problem was resolved simply by updating hardhat.

Also, a universal liquidator logic available on polygon might be helpful soon?

Rewards for staking are WMATIC ("platformToken") and MTA ("rewardToken"), gains for the user are rewards plus the "autocompounded" yield of imUSD through the SavingsContract.

Liquidation is done from reward tokens to WETH, and from WETH to underlying (mUSD). 
WMATIC -> WETH has most liquidity and by far enough on quickswap. 
MTA almost exclusively has liquidity on balancer (1inch also routes 100% via balancer). We swap MTA to WETH on balancer. This has the least liquidity and other ideas would be welcome:
![image](https://user-images.githubusercontent.com/6112929/138826794-7dd10b25-7efd-4f0e-82f9-2e292a7413b6.png)

For WETH -> mUSD we first swap WETH to DAI on quickswap, and then mint mUSD directly on mStable.

The Staking currently has set rewards for "platformToken" (WMATIC) to 0, see https://polygonscan.com/token/0x32aba856dc5ffd5a56bcd182b13380e5c855aa29#readProxyContract. 
This can also be seen in the following test where I included a log output for the earnings:
```
  Polygon Mainnet mStable mUSD
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
0x0C2eF8a1b3Bc00Bf676053732F31a67ebbA5bD81
Fetching Underlying at:  0xE840B73E5287865EEc17d250bFb1536704B43B21
New Vault Deployed:  0xB492fAEdA6c9FFb9B9854a58F28d5333Ff7a11bc
Strategy Deployed:  0xa5B74477BE4f72E55A2e5d6CfFCF66DE1f39F321
Strategy and vault added to Controller.
    Happy path
loop  0
earned rewards: (MTA, WMATIC) 0 0
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
loop  1
earned rewards: (MTA, WMATIC) 739915359083608011 0
old shareprice:  1000000000000000000
new shareprice:  1000230763376286566
growth:  1.0002307633762866
loop  2
earned rewards: (MTA, WMATIC) 740836443341709632 0
old shareprice:  1000230763376286566
new shareprice:  1000342585571619906
growth:  1.0001117963968194
loop  3
earned rewards: (MTA, WMATIC) 739344678700123875 0
old shareprice:  1000342585571619906
new shareprice:  1000454182399368623
growth:  1.0001115586093787
loop  4
earned rewards: (MTA, WMATIC) 739444218410145956 0
old shareprice:  1000454182399368623
new shareprice:  1000565794051884881
growth:  1.0001115609834812
loop  5
earned rewards: (MTA, WMATIC) 739509536320619188 0
old shareprice:  1000565794051884881
new shareprice:  1000677415363666239
growth:  1.0001115581928193
loop  6
earned rewards: (MTA, WMATIC) 739591977720592678 0
old shareprice:  1000677415363666239
new shareprice:  1000789048919266969
growth:  1.0001115579845081
loop  7
earned rewards: (MTA, WMATIC) 739674428150983712 0
old shareprice:  1000789048919266969
new shareprice:  1000900694719983637
growth:  1.0001115577761739
loop  8
earned rewards: (MTA, WMATIC) 739756887612649117 0
old shareprice:  1000900694719983637
new shareprice:  1001012352767113103
growth:  1.0001115575678172
loop  9
earned rewards: (MTA, WMATIC) 739839356106591853 0
old shareprice:  1001012352767113103
new shareprice:  1001124023061952316
growth:  1.0001115573594377
earned!
APR: 9.020650922327823 %
APY: 9.438806706067426 %
      ✓ Farmer should earn money (175142ms)


  1 passing (4m)
```

The following is the actual test, clean of other logs. We can see the 9% is approximately in line with the rate of MTA rewards outlined in the staking part of the mStable app (https://mstable.app/#/musd/save). Not included in the test output APY is the Savings yield APY which according to mStable app should be around 16%.

Run test (`npx hardhat test ./test/mstable/mstable-musd.js`) at block `20604046`: 
```
Polygon Mainnet mStable mUSD
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
0x0C2eF8a1b3Bc00Bf676053732F31a67ebbA5bD81
Fetching Underlying at:  0xE840B73E5287865EEc17d250bFb1536704B43B21
New Vault Deployed:  0xB492fAEdA6c9FFb9B9854a58F28d5333Ff7a11bc
Strategy Deployed:  0xa5B74477BE4f72E55A2e5d6CfFCF66DE1f39F321
Strategy and vault added to Controller.
    Happy path
loop  0
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
loop  1
old shareprice:  1000000000000000000
new shareprice:  1000230755244897503
growth:  1.0002307552448975
loop  2
old shareprice:  1000230755244897503
new shareprice:  1000342572273432512
growth:  1.0001117912321218
loop  3
old shareprice:  1000342572273432512
new shareprice:  1000454169099765352
growth:  1.0001115586094464
loop  4
old shareprice:  1000454169099765352
new shareprice:  1000565778167324304
growth:  1.0001115584011804
loop  5
old shareprice:  1000565778167324304
new shareprice:  1000677402061230232
growth:  1.0001115607752549
loop  6
old shareprice:  1000677402061230232
new shareprice:  1000789035615414403
growth:  1.0001115579845754
loop  7
old shareprice:  1000789035615414403
new shareprice:  1000900681414714321
growth:  1.0001115577762414
loop  8
old shareprice:  1000900681414714321
new shareprice:  1001012339460427044
growth:  1.0001115575678845
loop  9
old shareprice:  1001012339460427044
new shareprice:  1001124009753849321
growth:  1.0001115573595052
earned!
APR: 9.020572635095837 %
APY: 9.438721050650244 %
      ✓ Farmer should earn money (161527ms)


  1 passing (3m)
```