### PR TITLE
New Jarvis base strategy and QUI-2CAD & SES-2JPY strategy implementations

### DIFF
--- a/contracts/strategies/jarvis/JarvisStrategyV3.sol
+++ b/contracts/strategies/jarvis/JarvisStrategyV3.sol
@@ -1,0 +1,281 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+
+import "@openzeppelin/contracts/math/Math.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
+import "@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol";
+import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
+
+import "../../base/upgradability/BaseUpgradeableStrategy.sol";
+
+import "./interface/IElysianFields.sol";
+
+import "../../base/interface/IVault.sol";
+import "../../base/interface/IStrategy.sol";
+import "../../base/interface/kyber/IDMMRouter02.sol";
+import "../../base/interface/kyber/IDMMPool.sol";
+import "../../base/interface/kyber/IKyberZap.sol";
+
+contract JarvisStrategyV3 is  BaseUpgradeableStrategy {
+
+  using SafeMath for uint256;
+  using SafeERC20 for IERC20;
+
+  address public constant kyberZapper = address(0x83D4908c1B4F9Ca423BEE264163BC1d50F251c31);
+  address public constant msig = address(0x39cC360806b385C96969ce9ff26c23476017F652);
+
+  // additional storage slots (on top of BaseUpgradeableStrategy ones) are defined here
+  bytes32 internal constant _POOLID_SLOT = 0x3fd729bfa2e28b7806b03a6e014729f59477b530f995be4d51defc9dad94810b;
+  bytes32 internal constant _REWARD_LP_SLOT = 0x48141e8830aff32be47daedfc211bdc62d1652246e1c94ca6dfd96128ee259d2;
+  bytes32 internal constant _REWARD_LP_TOKEN1_SLOT = 0x39bbed0fce4dadfae510b0ff92e23dc8458ac86daafb72558e64503559b640ed;
+
+  constructor() public BaseUpgradeableStrategy() {
+    assert(_POOLID_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.poolId")) - 1));
+    assert(_REWARD_LP_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.rewardLp")) - 1));
+    assert(_REWARD_LP_TOKEN1_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.rewardLpToken1")) - 1));
+  }
+
+  function initializeBaseStrategy(
+    address __storage,
+    address _underlying,
+    address _vault,
+    address _rewardPool,
+    address _rewardToken,
+    uint256 _poolId
+  ) public initializer {
+    require(_rewardPool != address(0), "reward pool is empty");
+
+    BaseUpgradeableStrategy.initialize({
+      _storage: __storage,
+      _underlying: _underlying,
+      _vault: _vault,
+      _rewardPool: _rewardPool,
+      _rewardToken: _rewardToken,
+      _profitSharingNumerator: 80,
+      _profitSharingDenominator: 1000,
+      _sell: true,
+      _sellFloor: 1e18,
+      _implementationChangeDelay: 12 hours}
+    );
+
+    address _lpt;
+    (_lpt,,,) = IElysianFields(_rewardPool).poolInfo(_poolId);
+
+    require(_lpt == _underlying, "Pool Info does not match underlying");
+
+    _setPoolId(_poolId);
+
+    address token0 = IDMMPool(_underlying).token0();
+    address token1 = IDMMPool(_underlying).token1();
+    require(token0 == _rewardToken || token1 == _rewardToken, "One of the underlying DMM pool token is not equal to the rewardToken");
+
+    // select the token that isn't the rewardToken, s.t.
+    address rewardLpToken1 = (token0 == _rewardToken) ? token1 : token0;
+    setRewardLpToken1(rewardLpToken1);
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                  STORAGE SETTER AND GETTER
+  //////////////////////////////////////////////////////////////*/
+
+  function setRewardLpToken1(address _value) public onlyGovernance {
+    setAddress(_REWARD_LP_TOKEN1_SLOT, _value);
+  }
+
+  function rewardLpToken1() public view returns (address) {
+    return getAddress(_REWARD_LP_TOKEN1_SLOT);
+  }
+
+  // masterchef rewards pool ID
+  function _setPoolId(uint256 _value) internal {
+    setUint256(_POOLID_SLOT, _value);
+  }
+
+  function poolId() public view returns (uint256) {
+    return getUint256(_POOLID_SLOT);
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                  PROXY - FINALIZE UPGRADE
+  //////////////////////////////////////////////////////////////*/
+
+  function finalizeUpgrade() external onlyGovernance {
+    _finalizeUpgrade();
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                  INTERNAL HELPER FUNCTIONS
+  //////////////////////////////////////////////////////////////*/
+
+  function _rewardPoolBalance() internal view returns (uint256 bal) {
+      (bal,) = IElysianFields(rewardPool()).userInfo(poolId(), address(this));
+  }
+
+  function _exitRewardPool() internal {
+      uint256 bal = _rewardPoolBalance();
+      if (bal != 0) {
+          IElysianFields(rewardPool()).withdraw(poolId(), bal);
+      }
+  }
+
+  function _emergencyExitRewardPool() internal {
+      uint256 bal = _rewardPoolBalance();
+      if (bal != 0) {
+          IElysianFields(rewardPool()).emergencyWithdraw(poolId());
+      }
+  }
+
+  function _enterRewardPool() internal {
+    address underlying_ = underlying();
+    address rewardPool_ = rewardPool();
+    uint256 entireBalance = IERC20(underlying_).balanceOf(address(this));
+
+    IERC20(underlying_).safeApprove(rewardPool_, 0);
+    IERC20(underlying_).safeApprove(rewardPool_, entireBalance);
+
+    IElysianFields(rewardPool_).deposit(poolId(), entireBalance);
+  }
+
+  function _liquidateReward() internal {
+    address rewardToken_ = rewardToken();
+    uint256 rewardBalance = IERC20(rewardToken_).balanceOf(address(this));
+    if (rewardBalance == 0) {
+      return;
+    }
+    uint256 feeAmount = rewardBalance.mul(profitSharingNumerator()).div(profitSharingDenominator());
+    IERC20(rewardToken_).safeTransfer(msig, feeAmount);
+    uint256 remainingRewardBalance = IERC20(rewardToken_).balanceOf(address(this));
+
+    if (remainingRewardBalance == 0) {
+      return;
+    }
+
+    _rewardToLp();
+  }
+
+  function _rewardToLp() internal {
+    address rewardToken_ = rewardToken();
+    uint256 rewardBalance = IERC20(rewardToken_).balanceOf(address(this));
+
+    IERC20(rewardToken_).safeApprove(kyberZapper, 0);
+    IERC20(rewardToken_).safeApprove(kyberZapper, rewardBalance);
+
+    IKyberZap(kyberZapper).zapIn({tokenIn: rewardToken_, tokenOut: rewardLpToken1(), userIn: rewardBalance , pool: underlying(), to: address(this), minLpQty: 1, deadline: block.timestamp});
+  }
+
+  /*
+  *   Stakes everything the strategy holds into the reward pool
+  */
+  function _investAllUnderlying() internal onlyNotPausedInvesting {
+    // this check is needed, because most of the SNX reward pools will revert if
+    // you try to stake(0).
+    if(IERC20(underlying()).balanceOf(address(this)) > 0) {
+      _enterRewardPool();
+    }
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                  PUBLIC EMERGENCY FUNCTIONS
+  //////////////////////////////////////////////////////////////*/
+
+  /*
+  *   In case there are some issues discovered about the pool or underlying asset
+  *   Governance can exit the pool properly
+  *   The function is only used for emergency to exit the pool
+  */
+  function emergencyExit() public onlyGovernance {
+    _emergencyExitRewardPool();
+    _setPausedInvesting(true);
+  }
+
+  /*
+  *   Resumes the ability to invest into the underlying reward pools
+  */
+  function continueInvesting() public onlyGovernance {
+    _setPausedInvesting(false);
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                  ISTRATEGY FUNCTION IMPLEMENTATIONS
+  //////////////////////////////////////////////////////////////*/
+
+  /*
+  *   Withdraws all the asset to the vault
+  */
+  function withdrawAllToVault() public restricted {
+    _exitRewardPool();
+    _liquidateReward();
+    address underlying_ = underlying();
+    IERC20(underlying_).safeTransfer(vault(), IERC20(underlying_).balanceOf(address(this)));
+  }
+
+  /*
+  *   Withdraws all the asset to the vault
+  */
+  function withdrawToVault(uint256 _amount) public restricted {
+    // Typically there wouldn't be any amount here
+    // however, it is possible because of the emergencyExit
+    address underlying_ = underlying();
+    uint256 entireBalance = IERC20(underlying_).balanceOf(address(this));
+
+    if(_amount > entireBalance){
+      // While we have the check above, we still using SafeMath below
+      // for the peace of mind (in case something gets changed in between)
+      uint256 needToWithdraw = _amount.sub(entireBalance);
+      uint256 toWithdraw = Math.min(_rewardPoolBalance(), needToWithdraw);
+      IElysianFields(rewardPool()).withdraw(poolId(), toWithdraw);
+    }
+
+    IERC20(underlying_).safeTransfer(vault(), _amount);
+  }
+
+  /*
+  *   Note that we currently do not have a mechanism here to include the
+  *   amount of reward that is accrued.
+  */
+  function investedUnderlyingBalance() external view returns (uint256) {
+    if (rewardPool() == address(0)) {
+      return IERC20(underlying()).balanceOf(address(this));
+    }
+    // Adding the amount locked in the reward pool and the amount that is somehow in this contract
+    // both are in the units of "underlying"
+    // The second part is needed because there is the emergency exit mechanism
+    // which would break the assumption that all the funds are always inside of the reward pool
+    return _rewardPoolBalance().add(IERC20(underlying()).balanceOf(address(this)));
+  }
+
+  /*
+  *   Governance or Controller can claim coins that are somehow transferred into the contract
+  *   Note that they cannot come in take away coins that are used and defined in the strategy itself
+  */
+  function salvage(address _recipient, address _token, uint256 _amount) external onlyControllerOrGovernance {
+     // To make sure that governance cannot come in and take away the coins
+    require(!unsalvagableTokens(_token), "token is defined as not salvagable");
+    IERC20(_token).safeTransfer(_recipient, _amount);
+  }
+
+  function unsalvagableTokens(address _token) public view returns (bool) {
+    return (_token == rewardToken() || _token == underlying());
+  }
+
+  /*
+  *   Get the reward, sell it in exchange for underlying, invest what you got.
+  *   It's not much, but it's honest work.
+  *
+  *   Note that although `onlyNotPausedInvesting` is not added here,
+  *   calling `_investAllUnderlying()` affectively blocks the usage of `doHardWork`
+  *   when the investing is being paused by governance.
+  */
+  function doHardWork() external onlyNotPausedInvesting restricted {
+    IElysianFields(rewardPool()).withdraw(poolId(), 0);
+    _liquidateReward();
+    _investAllUnderlying();
+  }
+
+ function depositArbCheck() public pure returns(bool) {
+    return true;
+  }
+
+}

--- a/contracts/strategies/jarvis/JarvisStrategyV3Mainnet_QUI_2CAD.sol
+++ b/contracts/strategies/jarvis/JarvisStrategyV3Mainnet_QUI_2CAD.sol
@@ -1,0 +1,27 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+
+import "./JarvisStrategyV3.sol";
+
+contract JarvisStrategyV3Mainnet_QUI_2CAD is JarvisStrategyV3 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address __storage,
+    address _vault
+  ) public initializer {
+    address underlying_ = address(0x32d8513eDDa5AEf930080F15270984A043933A95);
+    address rewardPool_ = address(0x16Ef7a2F8156819bAE95CFcE0CA712D01498b665);
+    address rewardToken_ = address(0xF65fb31ad1ccb2E7A6Ec3B34BEA4c81b68af6695);
+
+    JarvisStrategyV3.initializeBaseStrategy({
+      __storage: __storage,
+      _underlying: underlying_,
+      _vault: _vault,
+      _rewardPool: rewardPool_,
+      _rewardToken: rewardToken_,
+      _poolId: 1
+    });
+  }
+}

--- a/contracts/strategies/jarvis/JarvisStrategyV3Mainnet_SES_2JPY.sol
+++ b/contracts/strategies/jarvis/JarvisStrategyV3Mainnet_SES_2JPY.sol
@@ -1,0 +1,28 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+
+import "./JarvisStrategyV3.sol";
+
+contract JarvisStrategyV3Mainnet_SES_2JPY is JarvisStrategyV3 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address __storage,
+    address _vault
+  ) public initializer {
+    address underlying_ = address(0x3b76F90A8ab3EA7f0EA717F34ec65d194E5e9737);
+    address rewardPool_ = address(0xeb4a4Ba3EF5e3A286Dc49408C27F9BDaA286db84);
+    address rewardToken_ = address(0x9120ECada8dc70Dc62cBD49f58e861a09bf83788);
+
+    JarvisStrategyV3.initializeBaseStrategy({
+      __storage: __storage,
+      _underlying: underlying_,
+      _vault: _vault,
+      _rewardPool: rewardPool_,
+      _rewardToken: rewardToken_,
+      _poolId: 1
+    });
+  }
+}
+

--- a/test/jarvis/qui-2cad.js
+++ b/test/jarvis/qui-2cad.js
@@ -1,0 +1,218 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+
+const Strategy = artifacts.require("JarvisStrategyV3Mainnet_QUI_2CAD");
+
+//This test was developed at blockNumber 23900000
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Jarvis QUI-2CAD", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x2709fa6fa31bd336455d4f96ddfc505b3aca5a68";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x32d8513eDDa5AEf930080F15270984A043933A95");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 1e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+      let fTokenBalance = await vault.balanceOf(farmer1);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(fTokenBalance, { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("Overall APR:", apr*100, "%");
+      console.log("Overall APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+
+  describe("Basic strategy functionality checks", function () {
+    it("Deposit to vault", async function () {
+      // deposit to vault such that we have something to work with
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // check vault has at least farmerBalance (there could be some dust etc., so no exact check)
+      let vaultUnderlying = new BigNumber(await vault.underlyingBalanceInVault());
+      Utils.assertBNGte(vaultUnderlying, farmerBalance)
+    });
+
+    it("withdrawAllToVault()", async function () {
+      let vaultUnderlying = new BigNumber(await vault.underlyingBalanceInVault());
+      // doHardwork invests all underlying from the vault
+      await controller.doHardWork(vault.address, { from: governance });
+      let investedUnderlyingBalance = new BigNumber(await strategy.investedUnderlyingBalance());
+
+      // strategy invested amount must be greater or equal than the initial vault underlying amount
+      Utils.assertBNGte(investedUnderlyingBalance, vaultUnderlying)
+
+      // move all invested underlying back to the vault
+      await strategy.withdrawAllToVault({ from: governance });
+
+      // strategy has no underlying left
+      let investedUnderlyingBalanceNew = new BigNumber(await strategy.investedUnderlyingBalance());
+      assert.equal(investedUnderlyingBalanceNew.eq(BigNumber(0)), true);
+
+      // vault has all of the underlying from the strategy
+      let vaultUnderlyingNew = new BigNumber(await vault.underlyingBalanceInVault());
+      Utils.assertBNGte(vaultUnderlyingNew, investedUnderlyingBalance)
+    });
+
+    it("withdrawToVault(uint256 _amount)", async function () {
+      let vaultUnderlying = new BigNumber(await vault.underlyingBalanceInVault());
+      // doHardwork invests all underlying from the vault
+      await controller.doHardWork(vault.address, { from: governance });
+      let investedUnderlyingBalance = new BigNumber(await strategy.investedUnderlyingBalance());
+
+      // strategy invested amount must be greater or equal than the initial vault underlying amount
+      Utils.assertBNGte(investedUnderlyingBalance, vaultUnderlying)
+
+      let amount = 1;
+      // move amount of underlying to vault
+      await strategy.withdrawToVault(amount, { from: governance });
+
+      // vault has exactly amount of underlying
+      let vaultUnderlyingNew = new BigNumber(await vault.underlyingBalanceInVault());
+      assert.equal(new BigNumber(amount).eq(vaultUnderlyingNew), true);
+    });
+
+    it("emergencyExit()", async function () {
+      let vaultUnderlying = new BigNumber(await vault.underlyingBalanceInVault());
+      // doHardwork invests all underlying from the vault
+      await controller.doHardWork(vault.address, { from: governance });
+      let investedUnderlyingBalance = new BigNumber(await strategy.investedUnderlyingBalance());
+
+      // emergency exit of the strategy, moves all the underlying from the rewardPool to the strategy
+      await strategy.emergencyExit({ from: governance });
+      let isPausedInvesting = await strategy.pausedInvesting();
+
+      // flag _PAUSED_INVESTING_SLOT is set to true
+      assert.equal(isPausedInvesting, true);
+
+      // strategy has all the underlying
+      let investedUnderlyingBalanceNew = new BigNumber(await strategy.investedUnderlyingBalance());
+      let strategyBalance = new BigNumber(await underlying.balanceOf(strategy.address));
+      assert.equal(strategyBalance.eq(investedUnderlyingBalanceNew), true);
+
+      // set flag _PAUSED_INVESTING_SLOT to false
+      await strategy.continueInvesting({ from: governance });
+      isPausedInvesting = await strategy.pausedInvesting();
+      assert.equal(isPausedInvesting, false);
+
+    });
+
+    it("unsalvagableTokens(address _token)", async function () {
+      // underlying is unsalvageable
+      let isUnderlyingUnsalvagable = await strategy.unsalvagableTokens(underlying.address);
+      assert.equal(isUnderlyingUnsalvagable, true);
+
+      // rewardToken is unsalvageable
+      let isRewardTokenUnsalvagable = await strategy.unsalvagableTokens(await strategy.rewardToken());
+      assert.equal(isRewardTokenUnsalvagable, true);
+
+    });
+
+    it("Remove all deposited LP tokens", async function () {
+      // remove all deposited LP tokens
+      let fTokenBalance = await vault.balanceOf(farmer1);
+      await vault.withdraw(fTokenBalance, { from: farmer1 });
+
+      //check that there is nothing left in the strategy or vault
+      let strategyBalance = new BigNumber(await underlying.balanceOf(strategy.address));
+      assert.equal(strategyBalance.eq(BigNumber(0)), true);
+
+      let vaultBalance = new BigNumber(await underlying.balanceOf(vault.address));
+      assert.equal(vaultBalance.eq(BigNumber(0)), true);
+
+      let totalUnderlyingVaultAndStrategy = new BigNumber(await vault.underlyingBalanceWithInvestment());
+      assert.equal(totalUnderlyingVaultAndStrategy.eq(BigNumber(0)), true);
+    });
+  });
+
+});

--- a/test/jarvis/ses-2jpy.js
+++ b/test/jarvis/ses-2jpy.js
@@ -1,0 +1,222 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+
+const Strategy = artifacts.require("JarvisStrategyV3Mainnet_SES_2JPY");
+
+//This test was developed at blockNumber 23900000
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Jarvis SES-2JPY", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x2709fa6fa31bd336455d4f96ddfc505b3aca5a68";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x3b76F90A8ab3EA7f0EA717F34ec65d194E5e9737");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 1e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+      let fTokenBalance = await vault.balanceOf(farmer1);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(fTokenBalance, { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("Overall APR:", apr*100, "%");
+      console.log("Overall APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+
+
+
+  describe("Basic strategy functionality checks", function () {
+    it("Deposit to vault", async function () {
+      // deposit to vault such that we have something to work with
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // check vault has at least farmerBalance (there could be some dust etc., so no exact check)
+      let vaultUnderlying = new BigNumber(await vault.underlyingBalanceInVault());
+      Utils.assertBNGte(vaultUnderlying, farmerBalance)
+    });
+
+    it("withdrawAllToVault()", async function () {
+      let vaultUnderlying = new BigNumber(await vault.underlyingBalanceInVault());
+      // doHardwork invests all underlying from the vault
+      await controller.doHardWork(vault.address, { from: governance });
+      let investedUnderlyingBalance = new BigNumber(await strategy.investedUnderlyingBalance());
+
+      // strategy invested amount must be greater or equal than the initial vault underlying amount
+      Utils.assertBNGte(investedUnderlyingBalance, vaultUnderlying)
+
+      // move all invested underlying back to the vault
+      await strategy.withdrawAllToVault({ from: governance });
+
+      // strategy has no underlying left
+      let investedUnderlyingBalanceNew = new BigNumber(await strategy.investedUnderlyingBalance());
+      assert.equal(investedUnderlyingBalanceNew.eq(BigNumber(0)), true);
+
+      // vault has all of the underlying from the strategy
+      let vaultUnderlyingNew = new BigNumber(await vault.underlyingBalanceInVault());
+      Utils.assertBNGte(vaultUnderlyingNew, investedUnderlyingBalance)
+    });
+
+    it("withdrawToVault(uint256 _amount)", async function () {
+      let vaultUnderlying = new BigNumber(await vault.underlyingBalanceInVault());
+      // doHardwork invests all underlying from the vault
+      await controller.doHardWork(vault.address, { from: governance });
+      let investedUnderlyingBalance = new BigNumber(await strategy.investedUnderlyingBalance());
+
+      // strategy invested amount must be greater or equal than the initial vault underlying amount
+      Utils.assertBNGte(investedUnderlyingBalance, vaultUnderlying)
+
+      let amount = 1;
+      // move amount of underlying to vault
+      await strategy.withdrawToVault(amount, { from: governance });
+
+      // vault has exactly amount of underlying
+      let vaultUnderlyingNew = new BigNumber(await vault.underlyingBalanceInVault());
+      assert.equal(new BigNumber(amount).eq(vaultUnderlyingNew), true);
+    });
+
+    it("emergencyExit()", async function () {
+      let vaultUnderlying = new BigNumber(await vault.underlyingBalanceInVault());
+      // doHardwork invests all underlying from the vault
+      await controller.doHardWork(vault.address, { from: governance });
+      let investedUnderlyingBalance = new BigNumber(await strategy.investedUnderlyingBalance());
+
+      // emergency exit of the strategy, moves all the underlying from the rewardPool to the strategy
+      await strategy.emergencyExit({ from: governance });
+      let isPausedInvesting = await strategy.pausedInvesting();
+
+      // flag _PAUSED_INVESTING_SLOT is set to true
+      assert.equal(isPausedInvesting, true);
+
+      // strategy has all the underlying
+      let investedUnderlyingBalanceNew = new BigNumber(await strategy.investedUnderlyingBalance());
+      let strategyBalance = new BigNumber(await underlying.balanceOf(strategy.address));
+      assert.equal(strategyBalance.eq(investedUnderlyingBalanceNew), true);
+
+      // set flag _PAUSED_INVESTING_SLOT to false
+      await strategy.continueInvesting({ from: governance });
+      isPausedInvesting = await strategy.pausedInvesting();
+      assert.equal(isPausedInvesting, false);
+
+    });
+
+    it("unsalvagableTokens(address _token)", async function () {
+      // underlying is unsalvageable
+      let isUnderlyingUnsalvagable = await strategy.unsalvagableTokens(underlying.address);
+      assert.equal(isUnderlyingUnsalvagable, true);
+
+      // rewardToken is unsalvageable
+      let isRewardTokenUnsalvagable = await strategy.unsalvagableTokens(await strategy.rewardToken());
+      assert.equal(isRewardTokenUnsalvagable, true);
+
+    });
+
+    it("Remove all deposited LP tokens", async function () {
+      // remove all deposited LP tokens
+      let fTokenBalance = await vault.balanceOf(farmer1);
+      await vault.withdraw(fTokenBalance, { from: farmer1 });
+
+      //check that there is nothing left in the strategy or vault
+      let strategyBalance = new BigNumber(await underlying.balanceOf(strategy.address));
+      assert.equal(strategyBalance.eq(BigNumber(0)), true);
+
+      let vaultBalance = new BigNumber(await underlying.balanceOf(vault.address));
+      assert.equal(vaultBalance.eq(BigNumber(0)), true);
+
+      let totalUnderlyingVaultAndStrategy = new BigNumber(await vault.underlyingBalanceWithInvestment());
+      assert.equal(totalUnderlyingVaultAndStrategy.eq(BigNumber(0)), true);
+    });
+  });
+
+});


### PR DESCRIPTION
- New Jarvis base strategy with a new structure and some gas optimizations
- Overview of the Jarvis programs & contract addresses: https://yield.jarvis.network/info
- Basic structure from JarvisStrategyV2.sol
- Removed _REWARD_LP_SLOT from JarvisStrategyV2 because it is the same as the underlying token
- Implementation & tests for: QUI-2CAD & SES-2JPY
- Tests also check for basic strategy functionalities (e.g. emergencyExit())
- Starting block number is for both tests: 23900000 (it is the starting block of the farming program for QUI-2CAD)
- Sell / sell floor checks are not implemented for polygon streatgeies? Should this be added? Also, setter that can be called by governance?

### SES-2JPY
- npx hardhat test test/jarvis/ses-2jpy.js        
- Blocknumber: 23900000

```
  Mainnet Jarvis SES-2JPY
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
0x2709fa6fa31bd336455d4f96ddfc505b3aca5a68
Fetching Underlying at:  0x3b76F90A8ab3EA7f0EA717F34ec65d194E5e9737
New Vault Deployed:  0xc0774909E077361A3cC6E3114B971D1f1cCA727a
Strategy Deployed:  0xde377f9d6Fd109c455d9e04659a8a834F968e60B
Strategy and vault added to Controller.
    Happy path
loop  0
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
instant APR: 0 %
instant APY: 0 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  1
old shareprice:  1000000000000000000
new shareprice:  1002096637489713682
growth:  1.0020966374897136
instant APR: 367.3308881978157 %
instant APY: 3766.5515591826884 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  2
old shareprice:  1002096637489713682
new shareprice:  1004197443525601078
growth:  1.0020964106227819
instant APR: 367.2911411113844 %
instant APY: 3765.030328558541 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  3
old shareprice:  1004197443525601078
new shareprice:  1006302425327402030
growth:  1.0020961831912365
instant APR: 367.25129510463483 %
instant APY: 3763.505911074431 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  4
old shareprice:  1006302425327402030
new shareprice:  1008411590210772061
growth:  1.0020959552817175
instant APR: 367.21136535689993 %
instant APY: 3761.978891345633 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  5
old shareprice:  1008411590210772061
new shareprice:  1010524945523986805
growth:  1.0020957269171935
instant APR: 367.1713558923026 %
instant APY: 3760.449426724944 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  6
old shareprice:  1010524945523986805
new shareprice:  1012642498722358582
growth:  1.002095498194034
instant APR: 367.1312835947541 %
instant APY: 3758.918165634091 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  7
old shareprice:  1012642498722358582
new shareprice:  1014764257276570438
growth:  1.0020952691170764
instant APR: 367.0911493117781 %
instant APY: 3757.385143050045 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  8
old shareprice:  1014764257276570438
new shareprice:  1016890228632842581
growth:  1.0020950396518475
instant APR: 367.0509470036892 %
instant APY: 3755.850130985167 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  9
old shareprice:  1016890228632842581
new shareprice:  1019020420232470734
growth:  1.0020948097834435
instant APR: 367.0106740592928 %
instant APY: 3754.3130326490336 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
earned!
Overall APR: 370.63278843170383 %
Overall APY: 3895.0320057394792 %
      ✓ Farmer should earn money (113523ms)
    Basic strategy functionality checks
      ✓ Deposit to vault (45ms)
      ✓ withdrawAllToVault() (384ms)
      ✓ withdrawToVault(uint256 _amount) (176ms)
      ✓ emergencyExit() (258ms)
      ✓ unsalvagableTokens(address _token)
      ✓ Remove all deposited LP tokens (71ms)


  7 passing (2m)
```

### QUI-2CAD
- npx hardhat test test/jarvis/qui-2cad.js 
- Blocknumber: 23900000

```
  Mainnet Jarvis QUI-2CAD
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
0x2709fa6fa31bd336455d4f96ddfc505b3aca5a68
Fetching Underlying at:  0x32d8513eDDa5AEf930080F15270984A043933A95
New Vault Deployed:  0xc0774909E077361A3cC6E3114B971D1f1cCA727a
Strategy Deployed:  0xde377f9d6Fd109c455d9e04659a8a834F968e60B
Strategy and vault added to Controller.
    Happy path
loop  0
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
instant APR: 0 %
instant APY: 0 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  1
old shareprice:  1000000000000000000
new shareprice:  1124984285741207999
growth:  1.124984285741208
instant APR: 21897.246861859643 %
instant APY: 3.135599155947275e+76 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  2
old shareprice:  1124984285741207999
new shareprice:  1243269559416654404
growth:  1.105143934163945
instant APR: 18421.217265523173 %
instant APY: 5.8649024902525675e+66 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  3
old shareprice:  1243269559416654404
new shareprice:  1356017409868188243
growth:  1.0906865688117027
instant APR: 15888.286855810307 %
instant APY: 1.921260822943524e+59 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  4
old shareprice:  1356017409868188243
new shareprice:  1464089753470661132
growth:  1.0796983451805224
instant APR: 13963.15007562753 %
instant APY: 2.232260224219336e+53 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  5
old shareprice:  1464089753470661132
new shareprice:  1568147020694333406
growth:  1.071073011047992
instant APR: 12451.9915356082 %
instant APY: 3.3828888813302166e+48 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  6
old shareprice:  1568147020694333406
new shareprice:  1668708450949751907
growth:  1.0641275524095264
instant APR: 11235.147182149023 %
instant APY: 3.4599637695208475e+44 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  7
old shareprice:  1668708450949751907
new shareprice:  1766191008909685630
growth:  1.0584179686418267
instant APR: 10234.828106048035 %
instant APY: 1.5203430757384286e+41 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  8
old shareprice:  1766191008909685630
new shareprice:  1860935512826819319
growth:  1.0536434074452807
instant APR: 9398.324984413184 %
instant APY: 2.0842502180705553e+38 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  9
old shareprice:  1860935512826819319
new shareprice:  1953224763062536794
growth:  1.049592933016538
instant APR: 8688.681864497477 %
instant APY: 7.062122327951072e+35 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
earned!
Overall APR: 18278.554235142765 %
Overall APY: 2.2696609345228773e+66 %
      ✓ Farmer should earn money (124030ms)
    Basic strategy functionality checks
      ✓ Deposit to vault (47ms)
      ✓ withdrawAllToVault() (237ms)
      ✓ withdrawToVault(uint256 _amount) (151ms)
      ✓ emergencyExit() (239ms)
      ✓ unsalvagableTokens(address _token)
      ✓ Remove all deposited LP tokens (78ms)


  7 passing (2m)
```