### PR TITLE
Updating and adding new Jarvis vaults

### DIFF
--- a/contracts/strategies/jarvis/JarvisHodlStrategyV3Mainnet_2SGD.sol
+++ b/contracts/strategies/jarvis/JarvisHodlStrategyV3Mainnet_2SGD.sol
@@ -1,0 +1,34 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+
+import "./JarvisHodlStrategyV3.sol";
+
+contract JarvisHodlStrategyV3Mainnet_2SGD is JarvisHodlStrategyV3 {
+
+  address public sgd2_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address __storage,
+    address _vault
+  ) public initializer {
+    address underlying_ = address(0xeF75E9C7097842AcC5D0869E1dB4e5fDdf4BFDDA);
+    address rewardLp_ = address(0xdaa2C66B06B62bAd2E192be0A93f895c855484ee);
+    address rewardPool_ = address(0x0ff93e7CE954A7Ac2ADbBe8F635513cbDB497405);
+    address rewardToken_ = address(0xF5f480Edc68589B51F4217E6aA82Ef7Df5cf789e);
+    address hodlVault_ = address(0x95b730ED766F4e385016144fA30E96b78EBd09f5);
+
+    JarvisHodlStrategyV3.initializeBaseStrategy({
+    __storage: __storage,
+    _underlying: underlying_,
+    _vault: _vault,
+    _rewardPool: rewardPool_,
+    _rewardToken: rewardToken_,
+    _poolId: 2,
+    _rewardLp: rewardLp_,
+    _hodlVault: hodlVault_,
+    _potPool: address(0x0000000000000000000000000000000000000000) // manually set it later
+    });
+  }
+}

--- a/contracts/strategies/jarvis/JarvisStrategyV3Mainnet_JRTMAY22_USDC.sol
+++ b/contracts/strategies/jarvis/JarvisStrategyV3Mainnet_JRTMAY22_USDC.sol
@@ -1,0 +1,27 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+
+import "./JarvisStrategyV3.sol";
+
+contract JarvisStrategyV3Mainnet_JRTMAY22_USDC is JarvisStrategyV3 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address __storage,
+    address _vault
+  ) public initializer {
+    address underlying_ = address(0xdaa2C66B06B62bAd2E192be0A93f895c855484ee);
+    address rewardPool_ = address(0x0ff93e7CE954A7Ac2ADbBe8F635513cbDB497405);
+    address rewardToken_ = address(0xF5f480Edc68589B51F4217E6aA82Ef7Df5cf789e);
+
+    JarvisStrategyV3.initializeBaseStrategy({
+      __storage: __storage,
+      _underlying: underlying_,
+      _vault: _vault,
+      _rewardPool: rewardPool_,
+      _rewardToken: rewardToken_,
+      _poolId: 3
+    });
+  }
+}

--- a/test/jarvis/2cad-update.js
+++ b/test/jarvis/2cad-update.js
@@ -1,0 +1,177 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+const IController = artifacts.require("IController");
+const Vault = artifacts.require("Vault");
+const PotPool = artifacts.require("PotPool");
+
+const Strategy = artifacts.require("JarvisHodlStrategyV3Mainnet_2CAD");
+
+const D18 = new BigNumber(Math.pow(10, 18));
+
+//This test was developed at blockNumber 26045250
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Jarvis 2CAD HODL in LP - Update rewardPool", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0xC662B4f061B2fe7e1241916A417364Cb3Bc6f45c";
+  let vaultAddr = "0x2D165213df42C70B72FbE47670bA3b7e6DBfAB4a";
+  let potPoolAddr = "0x2f590EB4980ed49Ff9613E3098b61772970a7f36";
+  let hodlVaultAddr = "0x95b730ED766F4e385016144fA30E96b78EBd09f5";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xA69b0D5c0C401BBA2d5162138613B5E38584F63F");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 1e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+
+    controller = await IController.at(addresses.Controller);
+    vault = await Vault.at(vaultAddr);
+    hodlVault = await Vault.at(hodlVaultAddr);
+    strategy = await Strategy.at(await vault.strategy());
+    potPool = await PotPool.at(potPoolAddr);
+
+    await strategy.updateRewardPool(
+      "0x0ff93e7CE954A7Ac2ADbBe8F635513cbDB497405",
+      "0xF5f480Edc68589B51F4217E6aA82Ef7Df5cf789e",
+      "0xdaa2C66B06B62bAd2E192be0A93f895c855484ee",
+      1,
+      hodlVaultAddr,
+      {from: governance});
+
+    await potPool.addRewardToken(hodlVaultAddr, {from: governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerOldHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+      let fTokenBalance = new BigNumber(await vault.balanceOf(farmer1));
+
+      let erc20Vault = await IERC20.at(vault.address);
+      await erc20Vault.approve(potPool.address, fTokenBalance, {from: farmer1});
+      await potPool.stake(fTokenBalance, {from: farmer1});
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      let oldHodlSharePrice;
+      let newHodlSharePrice;
+      let oldPotPoolBalance;
+      let newPotPoolBalance;
+      let hodlPrice;
+      let lpPrice;
+      let oldValue;
+      let newValue;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        oldHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        oldPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+        await controller.doHardWork(vault.address, {from: governance});
+        await controller.doHardWork(hodlVault.address, {from: governance});
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        newHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        newPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+
+        hodlPrice = new BigNumber(22859414.60).times(D18);
+        lpPrice = new BigNumber(1.1255).times(D18);
+        console.log("Hodl price:", hodlPrice.toFixed()/D18.toFixed());
+        console.log("LP price:", lpPrice.toFixed()/D18.toFixed());
+
+        oldValue = (fTokenBalance.times(oldSharePrice).times(lpPrice)).div(1e36).plus((oldPotPoolBalance.times(oldHodlSharePrice).times(hodlPrice)).div(1e36));
+        newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((newPotPoolBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+        console.log("old value: ", oldValue.toFixed()/D18.toFixed());
+        console.log("new value: ", newValue.toFixed()/D18.toFixed());
+        console.log("growth: ", newValue.toFixed() / oldValue.toFixed());
+
+        console.log("HodlToken in potpool: ", newPotPoolBalance.toFixed());
+
+        apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      // withdrawAll to make sure no doHardwork is called when we do withdraw later.
+      await vault.withdrawAll({ from: governance });
+
+      // wait until all reward can be claimed by the farmer
+      await Utils.waitTime(86400 * 30 * 1000);
+      console.log("vaultBalance: ", fTokenBalance.toFixed());
+      await potPool.exit({from: farmer1});
+      await vault.withdraw(fTokenBalance.toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerNewHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      Utils.assertBNGte(farmerNewBalance, farmerOldBalance);
+      Utils.assertBNGt(farmerNewHodlBalance, farmerOldHodlBalance);
+
+      oldValue = (fTokenBalance.times(1e18).times(lpPrice)).div(1e36);
+      newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((farmerNewHodlBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+      apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("Overall APR:", apr*100, "%");
+      console.log("Overall APY:", (apy-1)*100, "%");
+
+      console.log("potpool totalShare: ", (new BigNumber(await potPool.totalSupply())).toFixed());
+      console.log("HodlToken in potpool: ", (new BigNumber(await hodlVault.balanceOf(potPool.address))).toFixed() );
+      console.log("Farmer got HodlToken from potpool: ", farmerNewHodlBalance.toFixed());
+      console.log("earned!");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});

--- a/test/jarvis/2jpy-update.js
+++ b/test/jarvis/2jpy-update.js
@@ -1,0 +1,177 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+const IController = artifacts.require("IController");
+const Vault = artifacts.require("Vault");
+const PotPool = artifacts.require("PotPool");
+
+const Strategy = artifacts.require("JarvisHodlStrategyV3Mainnet_2JPY");
+
+const D18 = new BigNumber(Math.pow(10, 18));
+
+//This test was developed at blockNumber 26045250
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Jarvis 2JPY HODL in LP - Update rewardPool", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0xC662B4f061B2fe7e1241916A417364Cb3Bc6f45c";
+  let vaultAddr = "0x9e00c8E675F3F25Ca0F7f51d4bCA28b7be009e12";
+  let potPoolAddr = "0x8451d905e6b4dEd563b5AB49027f28e2eBcCc991";
+  let hodlVaultAddr = "0x95b730ED766F4e385016144fA30E96b78EBd09f5";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xE8dCeA7Fb2Baf7a9F4d9af608F06d78a687F8d9A");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 1e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+
+    controller = await IController.at(addresses.Controller);
+    vault = await Vault.at(vaultAddr);
+    hodlVault = await Vault.at(hodlVaultAddr);
+    strategy = await Strategy.at(await vault.strategy());
+    potPool = await PotPool.at(potPoolAddr);
+
+    await strategy.updateRewardPool(
+      "0x0ff93e7CE954A7Ac2ADbBe8F635513cbDB497405",
+      "0xF5f480Edc68589B51F4217E6aA82Ef7Df5cf789e",
+      "0xdaa2C66B06B62bAd2E192be0A93f895c855484ee",
+      0,
+      hodlVaultAddr,
+      {from: governance});
+
+    await potPool.addRewardToken(hodlVaultAddr, {from: governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerOldHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+      let fTokenBalance = new BigNumber(await vault.balanceOf(farmer1));
+
+      let erc20Vault = await IERC20.at(vault.address);
+      await erc20Vault.approve(potPool.address, fTokenBalance, {from: farmer1});
+      await potPool.stake(fTokenBalance, {from: farmer1});
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      let oldHodlSharePrice;
+      let newHodlSharePrice;
+      let oldPotPoolBalance;
+      let newPotPoolBalance;
+      let hodlPrice;
+      let lpPrice;
+      let oldValue;
+      let newValue;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        oldHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        oldPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+        await controller.doHardWork(vault.address, {from: governance});
+        await controller.doHardWork(hodlVault.address, {from: governance});
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        newHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        newPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+
+        hodlPrice = new BigNumber(22859414.60).times(D18);
+        lpPrice = new BigNumber(0.0084).times(D18);
+        console.log("Hodl price:", hodlPrice.toFixed()/D18.toFixed());
+        console.log("LP price:", lpPrice.toFixed()/D18.toFixed());
+
+        oldValue = (fTokenBalance.times(oldSharePrice).times(lpPrice)).div(1e36).plus((oldPotPoolBalance.times(oldHodlSharePrice).times(hodlPrice)).div(1e36));
+        newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((newPotPoolBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+        console.log("old value: ", oldValue.toFixed()/D18.toFixed());
+        console.log("new value: ", newValue.toFixed()/D18.toFixed());
+        console.log("growth: ", newValue.toFixed() / oldValue.toFixed());
+
+        console.log("HodlToken in potpool: ", newPotPoolBalance.toFixed());
+
+        apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      // withdrawAll to make sure no doHardwork is called when we do withdraw later.
+      await vault.withdrawAll({ from: governance });
+
+      // wait until all reward can be claimed by the farmer
+      await Utils.waitTime(86400 * 30 * 1000);
+      console.log("vaultBalance: ", fTokenBalance.toFixed());
+      await potPool.exit({from: farmer1});
+      await vault.withdraw(fTokenBalance.toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerNewHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      Utils.assertBNGte(farmerNewBalance, farmerOldBalance);
+      Utils.assertBNGt(farmerNewHodlBalance, farmerOldHodlBalance);
+
+      oldValue = (fTokenBalance.times(1e18).times(lpPrice)).div(1e36);
+      newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((farmerNewHodlBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+      apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("Overall APR:", apr*100, "%");
+      console.log("Overall APY:", (apy-1)*100, "%");
+
+      console.log("potpool totalShare: ", (new BigNumber(await potPool.totalSupply())).toFixed());
+      console.log("HodlToken in potpool: ", (new BigNumber(await hodlVault.balanceOf(potPool.address))).toFixed() );
+      console.log("Farmer got HodlToken from potpool: ", farmerNewHodlBalance.toFixed());
+      console.log("earned!");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});

--- a/test/jarvis/2sgd-hodl.js
+++ b/test/jarvis/2sgd-hodl.js
@@ -1,0 +1,176 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+const Vault = artifacts.require("Vault");
+
+const Strategy = artifacts.require("JarvisHodlStrategyV3Mainnet_2SGD");
+
+const D18 = new BigNumber(Math.pow(10, 18));
+
+//This test was developed at blockNumber 26045250
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Jarvis 2SGD HODL in LP", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+  let hodlVault;
+
+  // external setup
+  let underlyingWhale = "0xc31249BA48763dF46388BA5C4E7565d62ed4801C";
+  let hodlVaultAddr = "0x95b730ED766F4e385016144fA30E96b78EBd09f5";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xeF75E9C7097842AcC5D0869E1dB4e5fDdf4BFDDA");
+    console.log("Fetching Underlying at: ", underlying.address);
+    hodlVault = await Vault.at(hodlVaultAddr);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 1e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy, potPool] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+      "rewardPool" : true,
+      "rewardPoolConfig": {
+        type: 'PotPool',
+        rewardTokens: [
+          hodlVaultAddr // fJRTMAY22-USDC
+        ]
+      },
+    });
+
+    await strategy.setPotPool(potPool.address, {from: governance});
+    await potPool.setRewardDistribution([strategy.address], true, {from: governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerOldHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+      let fTokenBalance = new BigNumber(await vault.balanceOf(farmer1));
+
+      let erc20Vault = await IERC20.at(vault.address);
+      await erc20Vault.approve(potPool.address, fTokenBalance, {from: farmer1});
+      await potPool.stake(fTokenBalance, {from: farmer1});
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      let oldHodlSharePrice;
+      let newHodlSharePrice;
+      let oldPotPoolBalance;
+      let newPotPoolBalance;
+      let hodlPrice;
+      let lpPrice;
+      let oldValue;
+      let newValue;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        oldHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        oldPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+        await controller.doHardWork(vault.address, {from: governance});
+        await controller.doHardWork(hodlVault.address, {from: governance});
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        newHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        newPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+
+        hodlPrice = new BigNumber(22859414.60).times(D18);
+        lpPrice = new BigNumber(0.74).times(D18);
+        console.log("Hodl price:", hodlPrice.toFixed()/D18.toFixed());
+        console.log("LP price:", lpPrice.toFixed()/D18.toFixed());
+
+        oldValue = (fTokenBalance.times(oldSharePrice).times(lpPrice)).div(1e36).plus((oldPotPoolBalance.times(oldHodlSharePrice).times(hodlPrice)).div(1e36));
+        newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((newPotPoolBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+        console.log("old value: ", oldValue.toFixed()/D18.toFixed());
+        console.log("new value: ", newValue.toFixed()/D18.toFixed());
+        console.log("growth: ", newValue.toFixed() / oldValue.toFixed());
+
+        console.log("HodlToken in potpool: ", newPotPoolBalance.toFixed());
+
+        apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      // withdrawAll to make sure no doHardwork is called when we do withdraw later.
+      await vault.withdrawAll({ from: governance });
+
+      // wait until all reward can be claimed by the farmer
+      await Utils.waitTime(86400 * 30 * 1000);
+      console.log("vaultBalance: ", fTokenBalance.toFixed());
+      await potPool.exit({from: farmer1});
+      await vault.withdraw(fTokenBalance.toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerNewHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      Utils.assertBNGte(farmerNewBalance, farmerOldBalance);
+      Utils.assertBNGt(farmerNewHodlBalance, farmerOldHodlBalance);
+
+      oldValue = (fTokenBalance.times(1e18).times(lpPrice)).div(1e36);
+      newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((farmerNewHodlBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+      apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("Overall APR:", apr*100, "%");
+      console.log("Overall APY:", (apy-1)*100, "%");
+
+      console.log("potpool totalShare: ", (new BigNumber(await potPool.totalSupply())).toFixed());
+      console.log("hodlToken in potpool: ", (new BigNumber(await hodlVault.balanceOf(potPool.address))).toFixed() );
+      console.log("Farmer got HodlToken from potpool: ", farmerNewHodlBalance.toFixed());
+      console.log("earned!");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});

--- a/test/jarvis/jrtmay22-usdc.js
+++ b/test/jarvis/jrtmay22-usdc.js
@@ -1,0 +1,115 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+
+const Strategy = artifacts.require("JarvisStrategyV3Mainnet_JRTMAY22_USDC");
+
+//This test was developed at blockNumber 26045000
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Jarvis JRTMAY22-USDC", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x9ba961989Dd6609Ed091f512bE947118c40F2291";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xdaa2C66B06B62bAd2E192be0A93f895c855484ee");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 1e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+      let fTokenBalance = await vault.balanceOf(farmer1);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 7500;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(fTokenBalance, { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("Overall APR:", apr*100, "%");
+      console.log("Overall APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});


### PR DESCRIPTION
Updating the strategies for 2CAD and 2JPY, adding new 2SGD vault, and adding the new "rewardLP" vault for JRT-MAY22 - USDC.

Transactions that need to be made to finalize the updates:

`2SGD`:
- Call `setPotPool()` on the strategy contract with potPool address as argument. (Strategy: `0x7F34356ED033715FD467b2D5a04827C13aF834fF`, potPool: `0x917D36698F7195B32C3dF66Af45556eD447C79Fe`)
- Call `setRewardDistribution()` on the potPool contract to add the strategy as rewardDistribution. (Strategy: `0x7F34356ED033715FD467b2D5a04827C13aF834fF`, potPool: `0x917D36698F7195B32C3dF66Af45556eD447C79Fe`)

`2CAD`:
- Call `updateRewardPool()` on the strategy contract with: (Strategy: `0x2081afC37F39274Ed5ad41ED7F2c84e99b92C316`)
`_newRewardPool` = `0x0ff93e7CE954A7Ac2ADbBe8F635513cbDB497405`
`_newRewardToken` = `0xF5f480Edc68589B51F4217E6aA82Ef7Df5cf789e`
`_newRewardLP` = `0xdaa2C66B06B62bAd2E192be0A93f895c855484ee`
`_newPoolId` = 1
`_newHodlVault` = `0x95b730ED766F4e385016144fA30E96b78EBd09f5`

`2JPY`:
- Call `updateRewardPool()` on the strategy contract with: (Strategy: `0xEF9D1a246d013F4a8b16d9D875946abEb2AbEe68`)
`_newRewardPool` = `0x0ff93e7CE954A7Ac2ADbBe8F635513cbDB497405`
`_newRewardToken` = `0xF5f480Edc68589B51F4217E6aA82Ef7Df5cf789e`
`_newRewardLP` = `0xdaa2C66B06B62bAd2E192be0A93f895c855484ee`
`_newPoolId` = 0
`_newHodlVault` = `0x95b730ED766F4e385016144fA30E96b78EBd09f5`
