### PR TITLE
Jarvis updates and 2JPY migration

### DIFF
--- a/contracts/base/migration/vaultMigratable_2JPYv2.sol
+++ b/contracts/base/migration/vaultMigratable_2JPYv2.sol
@@ -5,8 +5,6 @@ import "../Vault.sol";
 import "../interface/curve/ICurveDeposit_2token.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
-import "hardhat/console.sol";
-
 interface IJPYCSwap {
   function swap() external;
 }

--- a/contracts/base/migration/vaultMigratable_2JPYv2.sol
+++ b/contracts/base/migration/vaultMigratable_2JPYv2.sol
@@ -1,0 +1,89 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+
+import "../Vault.sol";
+import "../interface/curve/ICurveDeposit_2token.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
+import "hardhat/console.sol";
+
+interface IJPYCSwap {
+  function swap() external;
+}
+
+contract VaultMigratable_2JPYv2 is Vault {
+  using SafeERC20 for IERC20;
+
+  address public constant __jjpy = address(0x8343091F2499FD4b6174A46D067A920a3b851FF9);
+  address public constant __jpyc = address(0x6AE7Dfc73E0dDE2aa99ac063DcF7e8A63265108c);
+  address public constant __jpycv2 = address(0x431D5dfF03120AFA4bDf332c61A6e1766eF37BDB);
+  address public constant __2jpy = address(0xE8dCeA7Fb2Baf7a9F4d9af608F06d78a687F8d9A);
+  address public constant __2jpyv2 = address(0xaA91CDD7abb47F821Cf07a2d38Cc8668DEAf1bdc);
+  address public constant __2jpyv2_strategy = address(0x45257F1c56bE3D381f49371b47c3EEb1E8358431);
+  address public constant __governance = address(0xf00dD244228F51547f0563e60bCa65a30FBF5f7f);
+
+  address public constant __jpyc_swap = address(0x382d78E8BcEa98fA04b63C19Fe97D8138C3bfC5D);
+
+  event Migrated(uint256 v1Liquidity, uint256 v2Liquidity);
+  event LiquidityRemoved(uint256 v1Liquidity, uint256 amountJJPY, uint256 amountJPYC);
+  event LiquidityProvided(uint256 JPYCv2Contributed, uint256 JJPYContributed, uint256 v2Liquidity);
+
+  constructor() public {
+  }
+
+  /**
+  * Migrates the vault from the 2JPY underlying to 2JPYv2 underlying
+  */
+  function migrateUnderlying(
+    uint256 minJJPYOut, uint256 minJPYCOut,
+    uint256 min2JPYv2Mint
+  ) public onlyControllerOrGovernance {
+    require(underlying() == __2jpy, "Can only migrate if the underlying is 2JPY");
+    withdrawAll();
+
+    uint256 v1Liquidity = IERC20(__2jpy).balanceOf(address(this));
+
+    ICurveDeposit_2token(__2jpy).remove_liquidity(v1Liquidity, [minJJPYOut, minJPYCOut]);
+    uint256 amountJJPY = IERC20(__jjpy).balanceOf(address(this));
+    uint256 amountJPYC = IERC20(__jpyc).balanceOf(address(this));
+
+    emit LiquidityRemoved(v1Liquidity, amountJJPY, amountJPYC);
+
+    require(IERC20(__2jpy).balanceOf(address(this)) == 0, "Not all underlying was converted");
+
+    IERC20(__jpyc).safeApprove(__jpyc_swap, 0);
+    IERC20(__jpyc).safeApprove(__jpyc_swap, uint256(-1));
+    IJPYCSwap(__jpyc_swap).swap();
+    uint256 jpycv2Balance = IERC20(__jpycv2).balanceOf(address(this));
+
+    IERC20(__jpycv2).safeApprove(__2jpyv2, 0);
+    IERC20(__jpycv2).safeApprove(__2jpyv2, jpycv2Balance);
+    IERC20(__jjpy).safeApprove(__2jpyv2, 0);
+    IERC20(__jjpy).safeApprove(__2jpyv2, amountJJPY);
+
+    ICurveDeposit_2token(__2jpyv2).add_liquidity([amountJJPY, jpycv2Balance], min2JPYv2Mint);
+    uint256 v2Liquidity = IERC20(__2jpyv2).balanceOf(address(this));
+
+    emit LiquidityProvided(jpycv2Balance, amountJJPY, v2Liquidity);
+
+    _setUnderlying(__2jpyv2);
+    require(underlying() == __2jpyv2, "underlying switch failed");
+    _setStrategy(__2jpyv2_strategy);
+    require(strategy() == __2jpyv2_strategy, "strategy switch failed");
+
+    // some steps that regular setStrategy does
+    IERC20(underlying()).safeApprove(address(strategy()), 0);
+    IERC20(underlying()).safeApprove(address(strategy()), uint256(~0));
+
+    uint256 jjpyLeft = IERC20(__jjpy).balanceOf(address(this));
+    if (jjpyLeft > 0) {
+      IERC20(__jjpy).transfer(__governance, jjpyLeft);
+    }
+    uint256 jpycv2Left = IERC20(__jpycv2).balanceOf(address(this));
+    if (jpycv2Left > 0) {
+      IERC20(__jpycv2).transfer(strategy(), jpycv2Left);
+    }
+
+    emit Migrated(v1Liquidity, v2Liquidity);
+  }
+}

--- a/contracts/strategies/jarvis/JarvisHodlStrategyV3Mainnet_2JPYv2.sol
+++ b/contracts/strategies/jarvis/JarvisHodlStrategyV3Mainnet_2JPYv2.sol
@@ -1,0 +1,34 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+
+import "./JarvisHodlStrategyV3.sol";
+
+contract JarvisHodlStrategyV3Mainnet_2JPYv2 is JarvisHodlStrategyV3 {
+
+  address public jpy2v2_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address __storage,
+    address _vault
+  ) public initializer {
+    address underlying_ = address(0xaA91CDD7abb47F821Cf07a2d38Cc8668DEAf1bdc);
+    address rewardLp_ = address(0x707C7f22d5E3C0234bCc53aeE51420d6cdD988f9);
+    address rewardPool_ = address(0xaB5053e1f6f7fb242f62091BEE8f15c81265EE05);
+    address rewardToken_ = address(0xD7f13BeE20D6848D9Ca2F26d9A244AB7bd6CDDc0);
+    address hodlVault_ = address(0xcFD80B11fefD581Fc45868ABD0d61e8437C050b1);
+
+    JarvisHodlStrategyV3.initializeBaseStrategy({
+    __storage: __storage,
+    _underlying: underlying_,
+    _vault: _vault,
+    _rewardPool: rewardPool_,
+    _rewardToken: rewardToken_,
+    _poolId: 0,
+    _rewardLp: rewardLp_,
+    _hodlVault: hodlVault_,
+    _potPool: address(0x0000000000000000000000000000000000000000) // manually set it later
+    });
+  }
+}

--- a/contracts/strategies/jarvis/JarvisHodlStrategyV3Mainnet_2NZD.sol
+++ b/contracts/strategies/jarvis/JarvisHodlStrategyV3Mainnet_2NZD.sol
@@ -1,0 +1,34 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+
+import "./JarvisHodlStrategyV3.sol";
+
+contract JarvisHodlStrategyV3Mainnet_2NZD is JarvisHodlStrategyV3 {
+
+  address public nzd2_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address __storage,
+    address _vault
+  ) public initializer {
+    address underlying_ = address(0x976A750168801F58E8AEdbCfF9328138D544cc09);
+    address rewardLp_ = address(0x707C7f22d5E3C0234bCc53aeE51420d6cdD988f9);
+    address rewardPool_ = address(0xaB5053e1f6f7fb242f62091BEE8f15c81265EE05);
+    address rewardToken_ = address(0xD7f13BeE20D6848D9Ca2F26d9A244AB7bd6CDDc0);
+    address hodlVault_ = address(0xcFD80B11fefD581Fc45868ABD0d61e8437C050b1);
+
+    JarvisHodlStrategyV3.initializeBaseStrategy({
+    __storage: __storage,
+    _underlying: underlying_,
+    _vault: _vault,
+    _rewardPool: rewardPool_,
+    _rewardToken: rewardToken_,
+    _poolId: 3,
+    _rewardLp: rewardLp_,
+    _hodlVault: hodlVault_,
+    _potPool: address(0x0000000000000000000000000000000000000000) // manually set it later
+    });
+  }
+}

--- a/contracts/strategies/jarvis/JarvisStrategyV3Mainnet_JRTJUL22_USDC.sol
+++ b/contracts/strategies/jarvis/JarvisStrategyV3Mainnet_JRTJUL22_USDC.sol
@@ -1,0 +1,27 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+
+import "./JarvisStrategyV3.sol";
+
+contract JarvisStrategyV3Mainnet_JRTJUL22_USDC is JarvisStrategyV3 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address __storage,
+    address _vault
+  ) public initializer {
+    address underlying_ = address(0x707C7f22d5E3C0234bCc53aeE51420d6cdD988f9);
+    address rewardPool_ = address(0xaB5053e1f6f7fb242f62091BEE8f15c81265EE05);
+    address rewardToken_ = address(0xD7f13BeE20D6848D9Ca2F26d9A244AB7bd6CDDc0);
+
+    JarvisStrategyV3.initializeBaseStrategy({
+      __storage: __storage,
+      _underlying: underlying_,
+      _vault: _vault,
+      _rewardPool: rewardPool_,
+      _rewardToken: rewardToken_,
+      _poolId: 4
+    });
+  }
+}

--- a/scripts/04-deploy-new-implementation.js
+++ b/scripts/04-deploy-new-implementation.js
@@ -1,0 +1,24 @@
+const prompt = require('prompt');
+const hre = require("hardhat");
+const { type2Transaction } = require('./utils.js');
+
+async function main() {
+  console.log("New implementation deployment.");
+  console.log("Specify the implementation contract's name");
+  prompt.start();
+  const addresses = require("../test/test-config.js");
+
+  const {implName} = await prompt.get(['implName']);
+
+  const ImplContract = artifacts.require(implName);
+  const impl = await type2Transaction(ImplContract.new);
+
+  console.log("Deployment complete. Implementation deployed at:", impl.creates);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/test/jarvis/2cad-update2.js
+++ b/test/jarvis/2cad-update2.js
@@ -1,0 +1,182 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+const IController = artifacts.require("IController");
+const Vault = artifacts.require("Vault");
+const PotPool = artifacts.require("PotPool");
+
+const Strategy = artifacts.require("JarvisHodlStrategyV3Mainnet_2CAD");
+
+const D18 = new BigNumber(Math.pow(10, 18));
+
+//This test was developed at blockNumber 28669600
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Jarvis 2CAD HODL in LP - Update rewardPool", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0xC662B4f061B2fe7e1241916A417364Cb3Bc6f45c";
+  let vaultAddr = "0x2D165213df42C70B72FbE47670bA3b7e6DBfAB4a";
+  let potPoolAddr = "0x2f590EB4980ed49Ff9613E3098b61772970a7f36";
+  let hodlVaultAddr = "0xcFD80B11fefD581Fc45868ABD0d61e8437C050b1";
+
+  let rewardPoolAddr = "0xaB5053e1f6f7fb242f62091BEE8f15c81265EE05";
+  let rewardTokenAddr = "0xD7f13BeE20D6848D9Ca2F26d9A244AB7bd6CDDc0";
+  let rewardLPAddr = "0x707C7f22d5E3C0234bCc53aeE51420d6cdD988f9";
+  let pid = 1;
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xA69b0D5c0C401BBA2d5162138613B5E38584F63F");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 1e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+
+    controller = await IController.at(addresses.Controller);
+    vault = await Vault.at(vaultAddr);
+    hodlVault = await Vault.at(hodlVaultAddr);
+    strategy = await Strategy.at(await vault.strategy());
+    potPool = await PotPool.at(potPoolAddr);
+
+    await strategy.updateRewardPool(
+      rewardPoolAddr,
+      rewardTokenAddr,
+      rewardLPAddr,
+      pid,
+      hodlVaultAddr,
+      {from: governance});
+
+    await potPool.addRewardToken(hodlVaultAddr, {from: governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerOldHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+      let fTokenBalance = new BigNumber(await vault.balanceOf(farmer1));
+
+      let erc20Vault = await IERC20.at(vault.address);
+      await erc20Vault.approve(potPool.address, fTokenBalance, {from: farmer1});
+      await potPool.stake(fTokenBalance, {from: farmer1});
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      let oldHodlSharePrice;
+      let newHodlSharePrice;
+      let oldPotPoolBalance;
+      let newPotPoolBalance;
+      let hodlPrice;
+      let lpPrice;
+      let oldValue;
+      let newValue;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        oldHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        oldPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+        await controller.doHardWork(vault.address, {from: governance});
+        await controller.doHardWork(hodlVault.address, {from: governance});
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        newHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        newPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+
+        hodlPrice = new BigNumber(85769646).times(D18);
+        lpPrice = new BigNumber(1.1255).times(D18);
+        console.log("Hodl price:", hodlPrice.toFixed()/D18.toFixed());
+        console.log("LP price:", lpPrice.toFixed()/D18.toFixed());
+
+        oldValue = (fTokenBalance.times(oldSharePrice).times(lpPrice)).div(1e36).plus((oldPotPoolBalance.times(oldHodlSharePrice).times(hodlPrice)).div(1e36));
+        newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((newPotPoolBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+        console.log("old value: ", oldValue.toFixed()/D18.toFixed());
+        console.log("new value: ", newValue.toFixed()/D18.toFixed());
+        console.log("growth: ", newValue.toFixed() / oldValue.toFixed());
+
+        console.log("HodlToken in potpool: ", newPotPoolBalance.toFixed());
+
+        apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      // withdrawAll to make sure no doHardwork is called when we do withdraw later.
+      await vault.withdrawAll({ from: governance });
+
+      // wait until all reward can be claimed by the farmer
+      await Utils.waitTime(86400 * 30 * 1000);
+      console.log("vaultBalance: ", fTokenBalance.toFixed());
+      await potPool.exit({from: farmer1});
+      await vault.withdraw(fTokenBalance.toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerNewHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      Utils.assertBNGte(farmerNewBalance, farmerOldBalance);
+      Utils.assertBNGt(farmerNewHodlBalance, farmerOldHodlBalance);
+
+      oldValue = (fTokenBalance.times(1e18).times(lpPrice)).div(1e36);
+      newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((farmerNewHodlBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+      apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("Overall APR:", apr*100, "%");
+      console.log("Overall APY:", (apy-1)*100, "%");
+
+      console.log("potpool totalShare: ", (new BigNumber(await potPool.totalSupply())).toFixed());
+      console.log("HodlToken in potpool: ", (new BigNumber(await hodlVault.balanceOf(potPool.address))).toFixed() );
+      console.log("Farmer got HodlToken from potpool: ", farmerNewHodlBalance.toFixed());
+      console.log("earned!");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});

--- a/test/jarvis/2jpyv2-upgrade.js
+++ b/test/jarvis/2jpyv2-upgrade.js
@@ -1,0 +1,184 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+const IController = artifacts.require("IController");
+const Vault = artifacts.require("Vault");
+const VaultProxy = artifacts.require("VaultProxy");
+const PotPool = artifacts.require("PotPool");
+
+const Strategy = artifacts.require("JarvisHodlStrategyV3Mainnet_2JPYv2");
+const MigratableVault = artifacts.require("VaultMigratable_2JPYv2")
+
+const D18 = new BigNumber(Math.pow(10, 18));
+
+//This test was developed at blockNumber 28669600
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Jarvis 2JPY HODL in LP - Migrate underlying and update strategy", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x77614f41b5489F1c11445c7661b7a3bB4F7631Bb";
+  let vaultAddr = "0x9e00c8E675F3F25Ca0F7f51d4bCA28b7be009e12";
+  let potPoolAddr = "0x8451d905e6b4dEd563b5AB49027f28e2eBcCc991";
+  let hodlVaultAddr = "0xcFD80B11fefD581Fc45868ABD0d61e8437C050b1";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xaA91CDD7abb47F821Cf07a2d38Cc8668DEAf1bdc");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 1e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+
+    controller = await IController.at(addresses.Controller);
+    vault = await Vault.at(vaultAddr);
+    hodlVault = await Vault.at(hodlVaultAddr);
+    potPool = await PotPool.at(potPoolAddr);
+
+    migratableVaultImpl = await MigratableVault.new();
+    await vault.scheduleUpgrade(migratableVaultImpl.address, {from: governance});
+    console.log("Vault upgrade announced. Waiting...");
+    await Utils.waitHours(13);
+    vault = await VaultProxy.at(vaultAddr);
+    await vault.upgrade({from: governance});
+
+    vault = await MigratableVault.at(vaultAddr);
+
+    await vault.migrateUnderlying(0, 0, 0, {from: governance});
+    strategy = await Strategy.at(await vault.strategy());
+
+    await strategy.setPotPool(potPool.address, {from: governance});
+    await potPool.setRewardDistribution([strategy.address], true, {from: governance});
+    await potPool.addRewardToken(hodlVaultAddr, {from: governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerOldHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+      let fTokenBalance = new BigNumber(await vault.balanceOf(farmer1));
+
+      let erc20Vault = await IERC20.at(vault.address);
+      await erc20Vault.approve(potPool.address, fTokenBalance, {from: farmer1});
+      await potPool.stake(fTokenBalance, {from: farmer1});
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      let oldHodlSharePrice;
+      let newHodlSharePrice;
+      let oldPotPoolBalance;
+      let newPotPoolBalance;
+      let hodlPrice;
+      let lpPrice;
+      let oldValue;
+      let newValue;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        oldHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        oldPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+        await controller.doHardWork(vault.address, {from: governance});
+        await controller.doHardWork(hodlVault.address, {from: governance});
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        newHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        newPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+
+        hodlPrice = new BigNumber(85769646).times(D18);
+        lpPrice = new BigNumber(0.0084).times(D18);
+        console.log("Hodl price:", hodlPrice.toFixed()/D18.toFixed());
+        console.log("LP price:", lpPrice.toFixed()/D18.toFixed());
+
+        oldValue = (fTokenBalance.times(oldSharePrice).times(lpPrice)).div(1e36).plus((oldPotPoolBalance.times(oldHodlSharePrice).times(hodlPrice)).div(1e36));
+        newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((newPotPoolBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+        console.log("old value: ", oldValue.toFixed()/D18.toFixed());
+        console.log("new value: ", newValue.toFixed()/D18.toFixed());
+        console.log("growth: ", newValue.toFixed() / oldValue.toFixed());
+
+        console.log("HodlToken in potpool: ", newPotPoolBalance.toFixed());
+
+        apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      // withdrawAll to make sure no doHardwork is called when we do withdraw later.
+      await vault.withdrawAll({ from: governance });
+
+      // wait until all reward can be claimed by the farmer
+      await Utils.waitTime(86400 * 30 * 1000);
+      console.log("vaultBalance: ", fTokenBalance.toFixed());
+      await potPool.exit({from: farmer1});
+      await vault.withdraw(fTokenBalance.toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerNewHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      Utils.assertBNGte(farmerNewBalance, farmerOldBalance);
+      Utils.assertBNGt(farmerNewHodlBalance, farmerOldHodlBalance);
+
+      oldValue = (fTokenBalance.times(1e18).times(lpPrice)).div(1e36);
+      newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((farmerNewHodlBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+      apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("Overall APR:", apr*100, "%");
+      console.log("Overall APY:", (apy-1)*100, "%");
+
+      console.log("potpool totalShare: ", (new BigNumber(await potPool.totalSupply())).toFixed());
+      console.log("HodlToken in potpool: ", (new BigNumber(await hodlVault.balanceOf(potPool.address))).toFixed() );
+      console.log("Farmer got HodlToken from potpool: ", farmerNewHodlBalance.toFixed());
+      console.log("earned!");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});

--- a/test/jarvis/2nzd-hodl.js
+++ b/test/jarvis/2nzd-hodl.js
@@ -1,0 +1,176 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+const Vault = artifacts.require("Vault");
+
+const Strategy = artifacts.require("JarvisHodlStrategyV3Mainnet_2NZD");
+
+const D18 = new BigNumber(Math.pow(10, 18));
+
+//This test was developed at blockNumber 28669150
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Jarvis 2NZD HODL in LP", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+  let hodlVault;
+
+  // external setup
+  let underlyingWhale = "0xCeBF0B9aA32AE4EE342cBAD2048eACf1634A0Ae0";
+  let hodlVaultAddr = "0xcFD80B11fefD581Fc45868ABD0d61e8437C050b1";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x976A750168801F58E8AEdbCfF9328138D544cc09");
+    console.log("Fetching Underlying at: ", underlying.address);
+    hodlVault = await Vault.at(hodlVaultAddr);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 1e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy, potPool] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+      "rewardPool" : true,
+      "rewardPoolConfig": {
+        type: 'PotPool',
+        rewardTokens: [
+          hodlVaultAddr // fJRTJUL22-USDC
+        ]
+      },
+    });
+
+    await strategy.setPotPool(potPool.address, {from: governance});
+    await potPool.setRewardDistribution([strategy.address], true, {from: governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerOldHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+      let fTokenBalance = new BigNumber(await vault.balanceOf(farmer1));
+
+      let erc20Vault = await IERC20.at(vault.address);
+      await erc20Vault.approve(potPool.address, fTokenBalance, {from: farmer1});
+      await potPool.stake(fTokenBalance, {from: farmer1});
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      let oldHodlSharePrice;
+      let newHodlSharePrice;
+      let oldPotPoolBalance;
+      let newPotPoolBalance;
+      let hodlPrice;
+      let lpPrice;
+      let oldValue;
+      let newValue;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        oldHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        oldPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+        await controller.doHardWork(vault.address, {from: governance});
+        await controller.doHardWork(hodlVault.address, {from: governance});
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        newHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        newPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+
+        hodlPrice = new BigNumber(85769646).times(D18);
+        lpPrice = new BigNumber(0.65).times(D18);
+        console.log("Hodl price:", hodlPrice.toFixed()/D18.toFixed());
+        console.log("LP price:", lpPrice.toFixed()/D18.toFixed());
+
+        oldValue = (fTokenBalance.times(oldSharePrice).times(lpPrice)).div(1e36).plus((oldPotPoolBalance.times(oldHodlSharePrice).times(hodlPrice)).div(1e36));
+        newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((newPotPoolBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+        console.log("old value: ", oldValue.toFixed()/D18.toFixed());
+        console.log("new value: ", newValue.toFixed()/D18.toFixed());
+        console.log("growth: ", newValue.toFixed() / oldValue.toFixed());
+
+        console.log("HodlToken in potpool: ", newPotPoolBalance.toFixed());
+
+        apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      // withdrawAll to make sure no doHardwork is called when we do withdraw later.
+      await vault.withdrawAll({ from: governance });
+
+      // wait until all reward can be claimed by the farmer
+      await Utils.waitTime(86400 * 30 * 1000);
+      console.log("vaultBalance: ", fTokenBalance.toFixed());
+      await potPool.exit({from: farmer1});
+      await vault.withdraw(fTokenBalance.toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerNewHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      Utils.assertBNGte(farmerNewBalance, farmerOldBalance);
+      Utils.assertBNGt(farmerNewHodlBalance, farmerOldHodlBalance);
+
+      oldValue = (fTokenBalance.times(1e18).times(lpPrice)).div(1e36);
+      newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((farmerNewHodlBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+      apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("Overall APR:", apr*100, "%");
+      console.log("Overall APY:", (apy-1)*100, "%");
+
+      console.log("potpool totalShare: ", (new BigNumber(await potPool.totalSupply())).toFixed());
+      console.log("hodlToken in potpool: ", (new BigNumber(await hodlVault.balanceOf(potPool.address))).toFixed() );
+      console.log("Farmer got HodlToken from potpool: ", farmerNewHodlBalance.toFixed());
+      console.log("earned!");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});

--- a/test/jarvis/2sgd-update.js
+++ b/test/jarvis/2sgd-update.js
@@ -1,0 +1,182 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+const IController = artifacts.require("IController");
+const Vault = artifacts.require("Vault");
+const PotPool = artifacts.require("PotPool");
+
+const Strategy = artifacts.require("JarvisHodlStrategyV3Mainnet_2SGD");
+
+const D18 = new BigNumber(Math.pow(10, 18));
+
+//This test was developed at blockNumber 28669600
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Jarvis 2SGD HODL in LP - Update rewardPool", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x7a9bAF7ad0b1d485D6eD07136ABf1490244d9155";
+  let vaultAddr = "0x5AC8afa262C617bBA8Aa65a04E16CCfAc9e92350";
+  let potPoolAddr = "0x917D36698F7195B32C3dF66Af45556eD447C79Fe";
+  let hodlVaultAddr = "0xcFD80B11fefD581Fc45868ABD0d61e8437C050b1";
+
+  let rewardPoolAddr = "0xaB5053e1f6f7fb242f62091BEE8f15c81265EE05";
+  let rewardTokenAddr = "0xD7f13BeE20D6848D9Ca2F26d9A244AB7bd6CDDc0";
+  let rewardLPAddr = "0x707C7f22d5E3C0234bCc53aeE51420d6cdD988f9";
+  let pid = 2;
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xeF75E9C7097842AcC5D0869E1dB4e5fDdf4BFDDA");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 1e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+
+    controller = await IController.at(addresses.Controller);
+    vault = await Vault.at(vaultAddr);
+    hodlVault = await Vault.at(hodlVaultAddr);
+    strategy = await Strategy.at(await vault.strategy());
+    potPool = await PotPool.at(potPoolAddr);
+
+    await strategy.updateRewardPool(
+      rewardPoolAddr,
+      rewardTokenAddr,
+      rewardLPAddr,
+      pid,
+      hodlVaultAddr,
+      {from: governance});
+
+    await potPool.addRewardToken(hodlVaultAddr, {from: governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerOldHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+      let fTokenBalance = new BigNumber(await vault.balanceOf(farmer1));
+
+      let erc20Vault = await IERC20.at(vault.address);
+      await erc20Vault.approve(potPool.address, fTokenBalance, {from: farmer1});
+      await potPool.stake(fTokenBalance, {from: farmer1});
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      let oldHodlSharePrice;
+      let newHodlSharePrice;
+      let oldPotPoolBalance;
+      let newPotPoolBalance;
+      let hodlPrice;
+      let lpPrice;
+      let oldValue;
+      let newValue;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        oldHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        oldPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+        await controller.doHardWork(vault.address, {from: governance});
+        await controller.doHardWork(hodlVault.address, {from: governance});
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        newHodlSharePrice = new BigNumber(await hodlVault.getPricePerFullShare());
+        newPotPoolBalance = new BigNumber(await hodlVault.balanceOf(potPool.address));
+
+        hodlPrice = new BigNumber(85769646).times(D18);
+        lpPrice = new BigNumber(1.1255).times(D18);
+        console.log("Hodl price:", hodlPrice.toFixed()/D18.toFixed());
+        console.log("LP price:", lpPrice.toFixed()/D18.toFixed());
+
+        oldValue = (fTokenBalance.times(oldSharePrice).times(lpPrice)).div(1e36).plus((oldPotPoolBalance.times(oldHodlSharePrice).times(hodlPrice)).div(1e36));
+        newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((newPotPoolBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+        console.log("old value: ", oldValue.toFixed()/D18.toFixed());
+        console.log("new value: ", newValue.toFixed()/D18.toFixed());
+        console.log("growth: ", newValue.toFixed() / oldValue.toFixed());
+
+        console.log("HodlToken in potpool: ", newPotPoolBalance.toFixed());
+
+        apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      // withdrawAll to make sure no doHardwork is called when we do withdraw later.
+      await vault.withdrawAll({ from: governance });
+
+      // wait until all reward can be claimed by the farmer
+      await Utils.waitTime(86400 * 30 * 1000);
+      console.log("vaultBalance: ", fTokenBalance.toFixed());
+      await potPool.exit({from: farmer1});
+      await vault.withdraw(fTokenBalance.toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      let farmerNewHodlBalance = new BigNumber(await hodlVault.balanceOf(farmer1));
+      Utils.assertBNGte(farmerNewBalance, farmerOldBalance);
+      Utils.assertBNGt(farmerNewHodlBalance, farmerOldHodlBalance);
+
+      oldValue = (fTokenBalance.times(1e18).times(lpPrice)).div(1e36);
+      newValue = (fTokenBalance.times(newSharePrice).times(lpPrice)).div(1e36).plus((farmerNewHodlBalance.times(newHodlSharePrice).times(hodlPrice)).div(1e36));
+
+      apr = (newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((newValue.toFixed()/oldValue.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("Overall APR:", apr*100, "%");
+      console.log("Overall APY:", (apy-1)*100, "%");
+
+      console.log("potpool totalShare: ", (new BigNumber(await potPool.totalSupply())).toFixed());
+      console.log("HodlToken in potpool: ", (new BigNumber(await hodlVault.balanceOf(potPool.address))).toFixed() );
+      console.log("Farmer got HodlToken from potpool: ", farmerNewHodlBalance.toFixed());
+      console.log("earned!");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});

--- a/test/jarvis/jrtjul22-usdc.js
+++ b/test/jarvis/jrtjul22-usdc.js
@@ -1,0 +1,115 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+
+const Strategy = artifacts.require("JarvisStrategyV3Mainnet_JRTJUL22_USDC");
+
+//This test was developed at blockNumber 28668800
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Jarvis JRTJUL22-USDC", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0xc31249BA48763dF46388BA5C4E7565d62ed4801C";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x707C7f22d5E3C0234bCc53aeE51420d6cdD988f9");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 1e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+      let fTokenBalance = await vault.balanceOf(farmer1);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 7500;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(fTokenBalance, { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("Overall APR:", apr*100, "%");
+      console.log("Overall APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});


### PR DESCRIPTION
A bunch of updates for the new reward program for Jarvis' 2JPY, 2CAD, 2SGD and new 2NZD pools. Quite some setup transactions still need to be made by governance, I'll outline them below.

-------------------------------------
The 2CAD and 2SGD strategies only need to be updated for the new rewardPool, and need the new hodlVault token to be added to their PotPools:

**2CAD**:
Call `updateRewardPool()` on the strategy contract with: (Strategy: `0x2081afC37F39274Ed5ad41ED7F2c84e99b92C316`)
`_newRewardPool` = `0xaB5053e1f6f7fb242f62091BEE8f15c81265EE05`
`_newRewardToken` = `0xD7f13BeE20D6848D9Ca2F26d9A244AB7bd6CDDc0`
`_newRewardLP` = `0x707C7f22d5E3C0234bCc53aeE51420d6cdD988f9`
`_newPoolId` = `1`
`_newHodlVault` = `0xcFD80B11fefD581Fc45868ABD0d61e8437C050b1`

Call `addRewardToken()` on the potpool contract with: (PotPool: `0x2f590EB4980ed49Ff9613E3098b61772970a7f36`)
`rt` = `0xcFD80B11fefD581Fc45868ABD0d61e8437C050b1`

**2SGD**:
Call `updateRewardPool()` on the strategy contract with: (Strategy: `0x7F34356ED033715FD467b2D5a04827C13aF834fF`)
`_newRewardPool` = `0xaB5053e1f6f7fb242f62091BEE8f15c81265EE05`
`_newRewardToken` = `0xD7f13BeE20D6848D9Ca2F26d9A244AB7bd6CDDc0`
`_newRewardLP` = `0x707C7f22d5E3C0234bCc53aeE51420d6cdD988f9`
`_newPoolId` = `2`
`_newHodlVault` = `0xcFD80B11fefD581Fc45868ABD0d61e8437C050b1`

Call `addRewardToken()` on the potpool contract with: (PotPool: `0x917D36698F7195B32C3dF66Af45556eD447C79Fe`)
`rt` = `0xcFD80B11fefD581Fc45868ABD0d61e8437C050b1`

-------------------------------------

Then, 2NZD is a new vault, which needs the following transactions for setup:

Call `setPotPool()` on the 2NZD strategy with: (Strategy: `0x34733CE813D289D05F17DCB3CB195b2128105f54`)
`potPool` = `0xfcD319Da00C632c2Fca0c95E147A5494973E6fC8`

Call `setRewardDistribution()` on the 2NZD potpool with: (PotPool: `0xfcD319Da00C632c2Fca0c95E147A5494973E6fC8`)
`_newRewardDistribution` = `[0x34733CE813D289D05F17DCB3CB195b2128105f54]`
`_flag` = `true`

Call `addRewardToken()` on the 2NZD potpool contract with: (PotPool: `0xfcD319Da00C632c2Fca0c95E147A5494973E6fC8`)
`rt` = `0xcFD80B11fefD581Fc45868ABD0d61e8437C050b1`

-------------------------------------

Finally, 2JPY needs an underlying migration, as JPYC (one of the underlying tokens) is migrating to JPYCv2. I've created and deployed a new vault implementation which includes a migration function to make this happen. The vault needs to be upgraded to this new implementation. To do:

Upgrade the 2JPY vault (`0x9e00c8E675F3F25Ca0F7f51d4bCA28b7be009e12`) to the new implementation: `0xf410024a8521d04a77ad8eA6d2dFE37C99e38760`

Call `migrateUnderlying()` on the vault contract after the upgrade. Parameters can be chosen to protect from slippage/front-running.

Call `setPotPool()` on the new 2JPYv2 strategy with: (Strategy: `0x45257F1c56bE3D381f49371b47c3EEb1E8358431`)
`potPool` = `0x8451d905e6b4dEd563b5AB49027f28e2eBcCc991`

Call `setRewardDistribution()` on the 2JPY potpool with: (PotPool: `0x8451d905e6b4dEd563b5AB49027f28e2eBcCc991`)
`_newRewardDistribution` = `[0x45257F1c56bE3D381f49371b47c3EEb1E8358431]`
`_flag` = `true`

Call `addRewardToken()` on the 2JPY potpool contract with: (PotPool: `0x8451d905e6b4dEd563b5AB49027f28e2eBcCc991`)
`rt` = `0xcFD80B11fefD581Fc45868ABD0d61e8437C050b1`

All these transactions were tested in the tests that are included in the PR. As always, let me know if anything is unclear!