### PR TITLE
New balancer strategies

### DIFF
--- a/contracts/strategies/balancer/BalancerStrategyV2.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV2.sol
@@ -1,0 +1,461 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/math/Math.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "../../base/interface/uniswap/IUniswapV2Router02.sol";
+import "../../base/interface/IVault.sol";
+import "../../base/upgradability/BaseUpgradeableStrategy.sol";
+import "../../base/interface/uniswap/IUniswapV2Pair.sol";
+import "./interface/IBVault.sol";
+import "../../base/interface/curve/Gauge.sol";
+
+contract BalancerStrategyV2 is BaseUpgradeableStrategy {
+
+  using SafeMath for uint256;
+  using SafeERC20 for IERC20;
+
+  address public constant quickswapRouterV2 = address(0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff);
+  address public constant sushiswapRouterV2 = address(0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506);
+  address public constant weth = address(0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619);
+  address public constant bal = address(0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3);
+  address public constant wmatic = address(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270);
+
+  // additional storage slots (on top of BaseUpgradeableStrategy ones) are defined here
+  bytes32 internal constant _POOLID_SLOT = 0x3fd729bfa2e28b7806b03a6e014729f59477b530f995be4d51defc9dad94810b;
+  bytes32 internal constant _BVAULT_SLOT = 0x85cbd475ba105ca98d9a2db62dcf7cf3c0074b36303ef64160d68a3e0fdd3c67;
+  bytes32 internal constant _USE_QUICK_SLOT = 0x189f8e6d384b6a451390d61330a1995a733994439125cd881a1bdac25fe65ea2;
+  bytes32 internal constant _DEPOSIT_TOKEN_SLOT = 0x219270253dbc530471c88a9e7c321b36afda219583431e7b6c386d2d46e70c86;
+  bytes32 internal constant _BAL2WETH_POOLID_SLOT = 0x45ba019d7bbdedd3bc4822691e4d804339c1a4b73290d1f7370a432fe65381d4;
+  bytes32 internal constant _DEPOSIT_ARRAY_INDEX_SLOT = 0xf5304231d5b8db321cd2f83be554278488120895d3326b9a012d540d75622ba3;
+  bytes32 internal constant _NTOKENS_SLOT = 0xbb60b35bae256d3c1378ff05e8d7bee588cd800739c720a107471dfa218f74c1;
+
+  // this would be reset on each upgrade
+  address[] public WETH2deposit;
+  address[] public poolAssets;
+  mapping (address => address[]) public reward2WETH;
+  mapping (address => bool) public useQuick;
+  address[] public rewardTokens;
+
+
+  constructor() public BaseUpgradeableStrategy() {
+    assert(_POOLID_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.poolId")) - 1));
+    assert(_BVAULT_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.bVault")) - 1));
+    assert(_USE_QUICK_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.useQuick")) - 1));
+    assert(_DEPOSIT_TOKEN_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.depositToken")) - 1));
+    assert(_BAL2WETH_POOLID_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.bal2WethPoolId")) - 1));
+    assert(_DEPOSIT_ARRAY_INDEX_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.depositArrayIndex")) - 1));
+    assert(_NTOKENS_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.nTokens")) - 1));
+  }
+
+  function initializeBaseStrategy(
+    address _storage,
+    address _underlying,
+    address _vault,
+    address _rewardPool,
+    address _bVault,
+    bytes32 _poolID,
+    address _depositToken,
+    uint256 _depositArrayIndex,
+    bytes32 _bal2wethpid,
+    uint256 _nTokens
+  ) public initializer {
+
+    BaseUpgradeableStrategy.initialize(
+      _storage,
+      _underlying,
+      _vault,
+      _rewardPool,
+      weth,
+      80, // profit sharing numerator
+      1000, // profit sharing denominator
+      true, // sell
+      1e18, // sell floor
+      12 hours // implementation change delay
+    );
+
+    (address _lpt,) = IBVault(_bVault).getPool(_poolID);
+    require(_lpt == _underlying, "Underlying mismatch");
+
+    _setPoolId(_poolID);
+    _setBal2WethPoolId(_bal2wethpid);
+    _setBVault(_bVault);
+    _setDepositToken(_depositToken);
+    _setNTokens(_nTokens);
+    _setDepositArrayIndex(_depositArrayIndex);
+    WETH2deposit = new address[](0);
+  }
+
+  function depositArbCheck() public pure returns(bool) {
+    return true;
+  }
+
+  function _rewardPoolBalance() internal view returns (uint256 balance) {
+      balance = Gauge(rewardPool()).balanceOf(address(this));
+  }
+
+  function _emergencyExitRewardPool() internal {
+    uint256 stakedBalance = _rewardPoolBalance();
+    if (stakedBalance != 0) {
+        _withdrawUnderlyingFromPool(stakedBalance);
+    }
+  }
+
+  function _withdrawUnderlyingFromPool(uint256 amount) internal {
+    address rewardPool_ = rewardPool();
+    Gauge(rewardPool_).withdraw(
+      Math.min(Gauge(rewardPool_).balanceOf(address(this)), amount)
+    );
+  }
+  function _enterRewardPool() internal {
+    address underlying_ = underlying();
+    address rewardPool_ = rewardPool();
+    uint256 entireBalance = IERC20(underlying_).balanceOf(address(this));
+    IERC20(underlying_).safeApprove(rewardPool_, 0);
+    IERC20(underlying_).safeApprove(rewardPool_, entireBalance);
+    Gauge(rewardPool_).deposit(entireBalance);
+  }
+
+  function _investAllUnderlying() internal onlyNotPausedInvesting {
+    // this check is needed, because most of the SNX reward pools will revert if
+    // you try to stake(0).
+    if(IERC20(underlying()).balanceOf(address(this)) > 0) {
+      _enterRewardPool();
+    }
+  }
+
+  /*
+  *   In case there are some issues discovered about the pool or underlying asset
+  *   Governance can exit the pool properly
+  *   The function is only used for emergency to exit the pool
+  */
+  function emergencyExit() public onlyGovernance {
+    _emergencyExitRewardPool();
+    _setPausedInvesting(true);
+  }
+
+  /*
+  *   Resumes the ability to invest into the underlying reward pools
+  */
+  function continueInvesting() public onlyGovernance {
+    _setPausedInvesting(false);
+  }
+
+  function unsalvagableTokens(address token) public view returns (bool) {
+    return (token == rewardToken() || token == underlying());
+  }
+
+  function setDepositLiquidationPath(address [] memory _route, bool _useQuick) public onlyGovernance {
+    require(_route[0] == weth, "Path should start with WETH");
+    require(_route[_route.length-1] == depositToken(), "Path should end with depositToken");
+    WETH2deposit = _route;
+    useQuick[_route[_route.length-1]] = _useQuick;
+  }
+
+  function setRewardLiquidationPath(address [] memory _route, bool _useQuick) public onlyGovernance {
+    require(_route[_route.length-1] == weth, "Path should end with WETH");
+    bool isReward = false;
+    for(uint256 i = 0; i < rewardTokens.length; i++){
+      if (_route[0] == rewardTokens[i]) {
+        isReward = true;
+      }
+    }
+    require(isReward, "Path should start with a rewardToken");
+    reward2WETH[_route[0]] = _route;
+    useQuick[_route[0]] = _useQuick;
+  }
+
+  function addRewardToken(address _token, address[] memory _path2WETH, bool _useQuick) public onlyGovernance {
+    rewardTokens.push(_token);
+    setRewardLiquidationPath(_path2WETH, _useQuick);
+  }
+
+  function changeDepositToken(address _depositToken, address[] memory _liquidationPath, bool _useQuick, uint256 _depositArrayIndex) public onlyGovernance {
+    _setDepositToken(_depositToken);
+    setDepositLiquidationPath(_liquidationPath, _useQuick);
+    _setDepositArrayIndex(_depositArrayIndex);
+  }
+
+  function _bal2WETH(uint256 balAmount) internal {
+    //swap bal to weth on balancer
+    IBVault.SingleSwap memory singleSwap;
+    IBVault.SwapKind swapKind = IBVault.SwapKind.GIVEN_IN;
+
+    singleSwap.poolId = bal2WethPoolId();
+    singleSwap.kind = swapKind;
+    singleSwap.assetIn = IAsset(bal);
+    singleSwap.assetOut = IAsset(weth);
+    singleSwap.amount = balAmount;
+    singleSwap.userData = abi.encode(0);
+
+    IBVault.FundManagement memory funds;
+    funds.sender = address(this);
+    funds.fromInternalBalance = false;
+    funds.recipient = payable(address(this));
+    funds.toInternalBalance = false;
+
+    IERC20(bal).safeApprove(bVault(), 0);
+    IERC20(bal).safeApprove(bVault(), balAmount);
+
+    IBVault(bVault()).swap(singleSwap, funds, 1, block.timestamp);
+  }
+
+  function _liquidateReward() internal {
+    if (!sell()) {
+      // Profits can be disabled for possible simplified and rapid exit
+      emit ProfitsNotCollected(sell(), false);
+      return;
+    }
+
+    for(uint256 i = 0; i < rewardTokens.length; i++){
+      address token = rewardTokens[i];
+      uint256 rewardBalance = IERC20(token).balanceOf(address(this));
+
+      if (rewardBalance == 0) {
+        continue;
+      }
+      if (token == bal) {
+        _bal2WETH(rewardBalance);
+      } else {
+        if (reward2WETH[token].length < 2) {
+          continue;
+        }
+        address routerV2;
+        if(useQuick[token]) {
+          routerV2 = quickswapRouterV2;
+        } else {
+          routerV2 = sushiswapRouterV2;
+        }
+        IERC20(token).safeApprove(routerV2, 0);
+        IERC20(token).safeApprove(routerV2, rewardBalance);
+        // we can accept 1 as the minimum because this will be called only by a trusted worker
+        IUniswapV2Router02(routerV2).swapExactTokensForTokens(
+          rewardBalance, 1, reward2WETH[token], address(this), block.timestamp
+        );
+      }
+    }
+
+    uint256 rewardBalance = IERC20(rewardToken()).balanceOf(address(this));
+    notifyProfitInRewardToken(rewardBalance);
+    uint256 remainingRewardBalance = IERC20(rewardToken()).balanceOf(address(this));
+
+    if (remainingRewardBalance == 0) {
+      return;
+    }
+
+    if (WETH2deposit.length > 1) { //else we assume WETH is the deposit token, no need to swap
+      address routerV2;
+      if(useQuick[depositToken()]) {
+        routerV2 = quickswapRouterV2;
+      } else {
+        routerV2 = sushiswapRouterV2;
+      }
+      // allow Uniswap to sell our reward
+      IERC20(rewardToken()).safeApprove(routerV2, 0);
+      IERC20(rewardToken()).safeApprove(routerV2, remainingRewardBalance);
+
+      // we can accept 1 as minimum because this is called only by a trusted role
+      uint256 amountOutMin = 1;
+
+      IUniswapV2Router02(routerV2).swapExactTokensForTokens(
+        remainingRewardBalance,
+        amountOutMin,
+        WETH2deposit,
+        address(this),
+        block.timestamp
+      );
+    }
+
+    uint256 tokenBalance = IERC20(depositToken()).balanceOf(address(this));
+    if (tokenBalance > 0) {
+      depositLP();
+    }
+  }
+
+  function depositLP() internal {
+    uint256 depositTokenBalance = IERC20(depositToken()).balanceOf(address(this));
+
+    IERC20(depositToken()).safeApprove(bVault(), 0);
+    IERC20(depositToken()).safeApprove(bVault(), depositTokenBalance);
+
+    IAsset[] memory assets = new IAsset[](nTokens());
+    for (uint256 i = 0; i < nTokens(); i++) {
+      assets[i] = IAsset(poolAssets[i]);
+    }
+
+    IBVault.JoinKind joinKind = IBVault.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT;
+    uint256[] memory amountsIn = new uint256[](nTokens());
+    amountsIn[depositArrayIndex()] = depositTokenBalance;
+    uint256 minAmountOut = 1;
+
+    bytes memory userData = abi.encode(joinKind, amountsIn, minAmountOut);
+
+    IBVault.JoinPoolRequest memory request;
+    request.assets = assets;
+    request.maxAmountsIn = amountsIn;
+    request.userData = userData;
+    request.fromInternalBalance = false;
+
+    IBVault(bVault()).joinPool(
+      poolId(),
+      address(this),
+      address(this),
+      request
+    );
+  }
+
+  /*
+  *   Withdraws all the asset to the vault
+  */
+  function withdrawAllToVault() public restricted {
+    _withdrawUnderlyingFromPool(_rewardPoolBalance());
+    _liquidateReward();
+    address underlying_ = underlying();
+    IERC20(underlying_).safeTransfer(vault(), IERC20(underlying_).balanceOf(address(this)));
+  }
+
+  /*
+  *   Withdraws all the asset to the vault
+  */
+  function withdrawToVault(uint256 _amount) public restricted {
+    // Typically there wouldn't be any amount here
+    // however, it is possible because of the emergencyExit
+    address underlying_ = underlying();
+    uint256 entireBalance = IERC20(underlying_).balanceOf(address(this));
+
+    if(_amount > entireBalance){
+      // While we have the check above, we still using SafeMath below
+      // for the peace of mind (in case something gets changed in between)
+      uint256 needToWithdraw = _amount.sub(entireBalance);
+      uint256 toWithdraw = Math.min(_rewardPoolBalance(), needToWithdraw);
+      _withdrawUnderlyingFromPool(toWithdraw);
+    }
+    IERC20(underlying_).safeTransfer(vault(), _amount);
+  }
+
+  /*
+  *   Note that we currently do not have a mechanism here to include the
+  *   amount of reward that is accrued.
+  */
+  function investedUnderlyingBalance() external view returns (uint256) {
+    if (rewardPool() == address(0)) {
+      return IERC20(underlying()).balanceOf(address(this));
+    }
+    // Adding the amount locked in the reward pool and the amount that is somehow in this contract
+    // both are in the units of "underlying"
+    // The second part is needed because there is the emergency exit mechanism
+    // which would break the assumption that all the funds are always inside of the reward pool
+    return _rewardPoolBalance().add(IERC20(underlying()).balanceOf(address(this)));
+  }
+
+  /*
+  *   Governance or Controller can claim coins that are somehow transferred into the contract
+  *   Note that they cannot come in take away coins that are used and defined in the strategy itself
+  */
+  function salvage(address recipient, address token, uint256 amount) external onlyControllerOrGovernance {
+     // To make sure that governance cannot come in and take away the coins
+    require(!unsalvagableTokens(token), "token is defined as not salvagable");
+    IERC20(token).safeTransfer(recipient, amount);
+  }
+
+  /*
+  *   Get the reward, sell it in exchange for underlying, invest what you got.
+  *   It's not much, but it's honest work.
+  *
+  *   Note that although `onlyNotPausedInvesting` is not added here,
+  *   calling `investAllUnderlying()` affectively blocks the usage of `doHardWork`
+  *   when the investing is being paused by governance.
+  */
+  function doHardWork() external onlyNotPausedInvesting restricted {
+    Gauge(rewardPool()).claim_rewards();
+    _liquidateReward();
+    _investAllUnderlying();
+  }
+
+  /**
+  * Can completely disable claiming UNI rewards and selling. Good for emergency withdraw in the
+  * simplest possible way.
+  */
+  function setSell(bool s) public onlyGovernance {
+    _setSell(s);
+  }
+
+  /**
+  * Sets the minimum amount of CRV needed to trigger a sale.
+  */
+  function setSellFloor(uint256 floor) public onlyGovernance {
+    _setSellFloor(floor);
+  }
+
+  // masterchef rewards pool ID
+  function _setPoolId(bytes32 _value) internal {
+    setBytes32(_POOLID_SLOT, _value);
+  }
+
+  function poolId() public view returns (bytes32) {
+    return getBytes32(_POOLID_SLOT);
+  }
+
+  function _setBVault(address _address) internal {
+    setAddress(_BVAULT_SLOT, _address);
+  }
+
+  function bVault() public view returns (address) {
+    return getAddress(_BVAULT_SLOT);
+  }
+
+  function _setDepositToken(address _address) internal {
+    setAddress(_DEPOSIT_TOKEN_SLOT, _address);
+  }
+
+  function depositToken() public view returns (address) {
+    return getAddress(_DEPOSIT_TOKEN_SLOT);
+  }
+
+  function _setBal2WethPoolId(bytes32 _value) internal {
+    setBytes32(_BAL2WETH_POOLID_SLOT, _value);
+  }
+
+  function bal2WethPoolId() public view returns (bytes32) {
+    return getBytes32(_BAL2WETH_POOLID_SLOT);
+  }
+
+  function _setDepositArrayIndex(uint256 _value) internal {
+    require(_value <= nTokens(), "Invalid index");
+    setUint256(_DEPOSIT_ARRAY_INDEX_SLOT, _value);
+  }
+
+  function depositArrayIndex() public view returns (uint256) {
+    return getUint256(_DEPOSIT_ARRAY_INDEX_SLOT);
+  }
+
+  function _setNTokens(uint256 _value) internal {
+    setUint256(_NTOKENS_SLOT, _value);
+  }
+
+  function nTokens() public view returns (uint256) {
+    return getUint256(_NTOKENS_SLOT);
+  }
+
+  function setBytes32(bytes32 slot, bytes32 _value) internal {
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      sstore(slot, _value)
+    }
+  }
+
+  function getBytes32(bytes32 slot) internal view returns (bytes32 str) {
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      str := sload(slot)
+    }
+  }
+
+  function finalizeUpgrade() external onlyGovernance {
+    _finalizeUpgrade();
+  }
+
+  receive() external payable {} // this is needed for the receiving Matic
+}

--- a/contracts/strategies/balancer/BalancerStrategyV2Mainnet_POLYBASE.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV2Mainnet_POLYBASE.sol
@@ -1,0 +1,36 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./BalancerStrategyV2.sol";
+
+contract BalancerStrategyV2Mainnet_POLYBASE is BalancerStrategyV2 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0x0297e37f1873D2DAb4487Aa67cD56B58E2F27875);
+    address wmatic = address(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270);
+    address usdc = address(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
+    address weth = address(0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619);
+    address bal = address(0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3);
+    address gauge = address(0x068Ff98072d3eB848D012e3390703BB507729ed6);
+    BalancerStrategyV2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      gauge,
+      address(0xBA12222222228d8Ba445958a75a0704d566BF2C8), //balancer vault
+      0x0297e37f1873d2dab4487aa67cd56b58e2f27875000100000000000000000002,  // Pool id
+      weth,   //depositToken
+      2,      //depositArrayIndex
+      0x0297e37f1873d2dab4487aa67cd56b58e2f27875000100000000000000000002, //bal2weth pid
+      4 //nTokens
+    );
+    poolAssets = [wmatic, usdc, weth, bal];
+    rewardTokens = [bal];
+  }
+}

--- a/contracts/strategies/balancer/BalancerStrategyV2Mainnet_STABLE.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV2Mainnet_STABLE.sol
@@ -1,0 +1,38 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./BalancerStrategyV2.sol";
+
+contract BalancerStrategyV2Mainnet_STABLE is BalancerStrategyV2 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0x06Df3b2bbB68adc8B0e302443692037ED9f91b42);
+    address usdt = address(0xc2132D05D31c914a87C6611C10748AEb04B58e8F);
+    address usdc = address(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
+    address mimatic = address(0xa3Fa99A148fA48D14Ed51d610c367C61876997F1);
+    address dai = address(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063);
+    address gauge = address(0x72843281394E68dE5d55BCF7072BB9B2eBc24150);
+    BalancerStrategyV2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      gauge,
+      address(0xBA12222222228d8Ba445958a75a0704d566BF2C8), //balancer vault
+      0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000012,  // Pool id
+      usdc,   //depositToken
+      0,      //depositArrayIndex
+      0x0297e37f1873d2dab4487aa67cd56b58e2f27875000100000000000000000002, //bal2weth pid
+      4 //nTokens
+    );
+    poolAssets = [usdc, dai, mimatic, usdt];
+    WETH2deposit = [weth, usdc];
+    rewardTokens = [bal];
+    useQuick[usdc] = true;
+  }
+}

--- a/contracts/strategies/balancer/BalancerStrategyV2Mainnet_USDC_WETH.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV2Mainnet_USDC_WETH.sol
@@ -1,0 +1,34 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./BalancerStrategyV2.sol";
+
+contract BalancerStrategyV2Mainnet_USDC_WETH is BalancerStrategyV2 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0x10f21C9bD8128a29Aa785Ab2dE0d044DCdd79436);
+    address usdc = address(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
+    address weth = address(0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619);
+    address gauge = address(0xD3Fdd06285d2649337800f00B41D07801C9f5715);
+    BalancerStrategyV2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      gauge,
+      address(0xBA12222222228d8Ba445958a75a0704d566BF2C8), //balancer vault
+      0x10f21c9bd8128a29aa785ab2de0d044dcdd79436000200000000000000000059,  // Pool id
+      weth,   //depositToken
+      1,      //depositArrayIndex
+      0x0297e37f1873d2dab4487aa67cd56b58e2f27875000100000000000000000002, //bal2weth pid
+      2 //nTokens
+    );
+    poolAssets = [usdc, weth];
+    rewardTokens = [bal];
+  }
+}

--- a/test/balancer/polybase_v2.js
+++ b/test/balancer/polybase_v2.js
@@ -1,0 +1,121 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+  swapMaticToToken,
+  addLiquidity,
+  wrapMATIC
+} = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("IERC20");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("BalancerStrategyV2Mainnet_POLYBASE");
+
+// Developed and tested at blockNumber 28790300
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Polygon Mainnet Balancer Polybase V2", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x7Ba7f4773fa7890BaD57879F0a1Faa0eDffB3520";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x0297e37f1873D2DAb4487Aa67cD56B58E2F27875");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000");
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": "0x5C6bC2287C48a2C9fc2f0533De2B2acFe7a9230A",
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "announceStrategy": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+
+    });
+  });
+});

--- a/test/balancer/stable_v2.js
+++ b/test/balancer/stable_v2.js
@@ -1,0 +1,121 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+  swapMaticToToken,
+  addLiquidity,
+  wrapMATIC
+} = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("IERC20");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("BalancerStrategyV2Mainnet_STABLE");
+
+// Developed and tested at blockNumber 28790300
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Polygon Mainnet Balancer Stable V2", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x13145e481f64685F2627ebF011559A843D5513Ef";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x06Df3b2bbB68adc8B0e302443692037ED9f91b42");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000");
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": "0x4f60a9471ACb094BA34AEA5EB7D7A4AD32c8890c",
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "announceStrategy": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+
+    });
+  });
+});

--- a/test/balancer/usdc_weth_v2.js
+++ b/test/balancer/usdc_weth_v2.js
@@ -1,0 +1,123 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+  swapMaticToToken,
+  addLiquidity,
+  wrapMATIC
+} = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("IERC20");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("BalancerStrategyV2Mainnet_USDC_WETH");
+
+// Developed and tested at blockNumber 28790300
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Polygon Mainnet Balancer USDC WETH V2", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+  let bal;
+  let wmatic;
+
+  // external setup
+  let underlyingWhale = "0xA55EdeE4c007c31112674350800D95614Ee69814";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x10f21C9bD8128a29Aa785Ab2dE0d044DCdd79436");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000");
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": "0x264B17DF8a79bFa830C1A94B90876CD3b0784b30",
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "announceStrategy": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+
+    });
+  });
+});


### PR DESCRIPTION
Created and deployed new strategies for some of our Balancer vaults. Balancer changed rewards from Merkle distribution to Gauge staking.

It was somehow impossible for me to verify the implementation contracts I deployed, but they are the exact same as the contracts you find in this commit. You could deploy them yourself to be sure, this is quite easily done using the `03-deploy-upgradable-strategy` script. The strategies should be updated by announcing strategy changes to the existing vaults.

**Deployments**:

**bal_Stable**:
`New strategy`: `0xBc129b0BC6df1DB2d4A1c5BD8E972F0398e78B86`
`Vault`: `0x4f60a9471ACb094BA34AEA5EB7D7A4AD32c8890c`

**bal_Polybase**:
`New strategy`: `0x89eFBba446c6690b1aa7FE8f15E2C93b249cEc23`
`Vault`: `0x5C6bC2287C48a2C9fc2f0533De2B2acFe7a9230A`

**bal_USDC_WETH**:
`New strategy`: `0x91B7e3164a069B1506EA4E0C64ee24513502BDdd`
`Vault`: `0x264B17DF8a79bFa830C1A94B90876CD3b0784b30`