### PR TITLE
Balancer v3

### DIFF
--- a/contracts/base/migration/vaultMigratable_bal2EUR_PAR.sol
+++ b/contracts/base/migration/vaultMigratable_bal2EUR_PAR.sol
@@ -1,0 +1,121 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "../Vault.sol";
+import "../interface/curve/ICurveDeposit_2token.sol";
+import "../../strategies/balancer/interface/IBVault.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
+import "hardhat/console.sol";
+
+contract VaultMigratable_bal2EUR_PAR is Vault {
+  using SafeERC20 for IERC20;
+
+  address public constant __token0 = address(0x4e3Decbb3645551B8A19f0eA1678079FCB33fB4c);
+  address public constant __token1 = address(0xE2Aa7db6dA1dAE97C5f5C6914d285fBfCC32A128);
+  address public constant __lpOld = address(0x0f110c55EfE62c16D553A3d3464B77e1853d0e97);
+  address public constant __lpNew = address(0x7d60a4Cb5cA92E2Da965637025122296ea6854f9);
+  address public constant __governance = address(0xf00dD244228F51547f0563e60bCa65a30FBF5f7f);
+  address public constant __bVault = address(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
+  address public constant __newStrategy = address(0x222E14Dc2f82d1d903e539C39B0C578B7353be7E);
+
+  bytes32 public constant __poolIdNew = 0x7d60a4cb5ca92e2da965637025122296ea6854f900000000000000000000085e;
+
+  event Migrated(uint256 v1Liquidity, uint256 v2Liquidity);
+  event LiquidityRemoved(uint256 v1Liquidity, uint256 amountToken0, uint256 amountToken1);
+  event LiquidityProvided(uint256 amountToken0, uint256 amountToken1, uint256 v2Liquidity);
+
+  constructor() public {
+  }
+
+  function _approveIfNeed(address token, address spender, uint256 amount) internal {
+    uint256 allowance = IERC20(token).allowance(address(this), spender);
+    if (amount > allowance) {
+      IERC20(token).safeApprove(spender, 0);
+      IERC20(token).safeApprove(spender, amount);
+    }
+  }
+
+  function _balancerSwap(
+    address sellToken,
+    address buyToken,
+    bytes32 poolId,
+    uint256 amountIn,
+    uint256 minAmountOut
+  ) internal {
+    IBVault.SingleSwap memory singleSwap;
+    IBVault.SwapKind swapKind = IBVault.SwapKind.GIVEN_IN;
+
+    singleSwap.poolId = poolId;
+    singleSwap.kind = swapKind;
+    singleSwap.assetIn = IAsset(sellToken);
+    singleSwap.assetOut = IAsset(buyToken);
+    singleSwap.amount = amountIn;
+    singleSwap.userData = abi.encode(0);
+
+    IBVault.FundManagement memory funds;
+    funds.sender = address(this);
+    funds.fromInternalBalance = false;
+    funds.recipient = payable(address(this));
+    funds.toInternalBalance = false;
+
+    _approveIfNeed(sellToken, __bVault, amountIn);
+    IBVault(__bVault).swap(singleSwap, funds, minAmountOut, block.timestamp);
+  }
+
+  /**
+  * Migrates the vault from the old Curve LP underlying to new Balancer LP underlying
+  */
+  function migrateUnderlying(
+    uint256 minToken0Out,
+    uint256 minToken1Out,
+    uint256 minLPNewOut
+  ) public onlyControllerOrGovernance {
+    require(underlying() == __lpOld, "Can only migrate if the underlying is lpOld");
+    withdrawAll();
+
+    uint256 v1Liquidity = IERC20(__lpOld).balanceOf(address(this));
+    console.log("V1Liquidity:     ", v1Liquidity);
+
+    ICurveDeposit_2token(__lpOld).remove_liquidity(v1Liquidity, [minToken0Out, minToken1Out]);
+    uint256 amount0 = IERC20(__token0).balanceOf(address(this));
+    uint256 amount1 = IERC20(__token1).balanceOf(address(this));
+    console.log("token0 out:      ", amount0);
+    console.log("token1 out:      ", amount1);
+
+    emit LiquidityRemoved(v1Liquidity, amount0, amount1);
+
+    require(IERC20(__lpOld).balanceOf(address(this)) == 0, "Not all underlying was converted");
+
+    _balancerSwap(__token0, __lpNew, __poolIdNew, amount0, 1);
+    _balancerSwap(__token1, __lpNew, __poolIdNew, amount1, 1);
+    uint256 v2Liquidity = IERC20(__lpNew).balanceOf(address(this));
+    require(v2Liquidity >= minLPNewOut, "Output amount too low");
+    console.log("V2Liquidity:     ", v2Liquidity);
+
+    emit LiquidityProvided(amount0, amount1, v2Liquidity);
+
+    _setUnderlying(__lpNew);
+    require(underlying() == __lpNew, "underlying switch failed");
+    console.log("New underlying:  ", underlying());
+    _setStrategy(__newStrategy);
+    require(strategy() == __newStrategy, "strategy switch failed");
+    console.log("New strategy:    ", strategy());
+
+    // some steps that regular setStrategy does
+    IERC20(underlying()).safeApprove(address(strategy()), 0);
+    IERC20(underlying()).safeApprove(address(strategy()), uint256(~0));
+
+    uint256 token0Left = IERC20(__token0).balanceOf(address(this));
+    if (token0Left > 0) {
+      IERC20(__token0).transfer(strategy(), token0Left);
+    }
+    uint256 token1Left = IERC20(__token1).balanceOf(address(this));
+    if (token1Left > 0) {
+      IERC20(__token1).transfer(__governance, token1Left);
+    }
+
+    emit Migrated(v1Liquidity, v2Liquidity);
+  }
+}

--- a/contracts/base/migration/vaultMigratable_bal2EUR_agEUR.sol
+++ b/contracts/base/migration/vaultMigratable_bal2EUR_agEUR.sol
@@ -1,0 +1,121 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "../Vault.sol";
+import "../interface/curve/ICurveDeposit_2token.sol";
+import "../../strategies/balancer/interface/IBVault.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
+import "hardhat/console.sol";
+
+contract VaultMigratable_bal2EUR_agEUR is Vault {
+  using SafeERC20 for IERC20;
+
+  address public constant __token0 = address(0x4e3Decbb3645551B8A19f0eA1678079FCB33fB4c);
+  address public constant __token1 = address(0xE0B52e49357Fd4DAf2c15e02058DCE6BC0057db4);
+  address public constant __lpOld = address(0x2fFbCE9099cBed86984286A54e5932414aF4B717);
+  address public constant __lpNew = address(0xa48D164F6eB0EDC68bd03B56fa59E12F24499aD1);
+  address public constant __governance = address(0xf00dD244228F51547f0563e60bCa65a30FBF5f7f);
+  address public constant __bVault = address(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
+  address public constant __newStrategy = address(0x044b1CfaDa044f9389DA761af520574E197dCCA4);
+
+  bytes32 public constant __poolIdNew = 0xa48d164f6eb0edc68bd03b56fa59e12f24499ad10000000000000000000007c4;
+
+  event Migrated(uint256 v1Liquidity, uint256 v2Liquidity);
+  event LiquidityRemoved(uint256 v1Liquidity, uint256 amountToken0, uint256 amountToken1);
+  event LiquidityProvided(uint256 amountToken0, uint256 amountToken1, uint256 v2Liquidity);
+
+  constructor() public {
+  }
+
+  function _approveIfNeed(address token, address spender, uint256 amount) internal {
+    uint256 allowance = IERC20(token).allowance(address(this), spender);
+    if (amount > allowance) {
+      IERC20(token).safeApprove(spender, 0);
+      IERC20(token).safeApprove(spender, amount);
+    }
+  }
+
+  function _balancerSwap(
+    address sellToken,
+    address buyToken,
+    bytes32 poolId,
+    uint256 amountIn,
+    uint256 minAmountOut
+  ) internal {
+    IBVault.SingleSwap memory singleSwap;
+    IBVault.SwapKind swapKind = IBVault.SwapKind.GIVEN_IN;
+
+    singleSwap.poolId = poolId;
+    singleSwap.kind = swapKind;
+    singleSwap.assetIn = IAsset(sellToken);
+    singleSwap.assetOut = IAsset(buyToken);
+    singleSwap.amount = amountIn;
+    singleSwap.userData = abi.encode(0);
+
+    IBVault.FundManagement memory funds;
+    funds.sender = address(this);
+    funds.fromInternalBalance = false;
+    funds.recipient = payable(address(this));
+    funds.toInternalBalance = false;
+
+    _approveIfNeed(sellToken, __bVault, amountIn);
+    IBVault(__bVault).swap(singleSwap, funds, minAmountOut, block.timestamp);
+  }
+
+  /**
+  * Migrates the vault from the old Curve LP underlying to new Balancer LP underlying
+  */
+  function migrateUnderlying(
+    uint256 minToken0Out,
+    uint256 minToken1Out,
+    uint256 minLPNewOut
+  ) public onlyControllerOrGovernance {
+    require(underlying() == __lpOld, "Can only migrate if the underlying is lpOld");
+    withdrawAll();
+
+    uint256 v1Liquidity = IERC20(__lpOld).balanceOf(address(this));
+    console.log("V1Liquidity:     ", v1Liquidity);
+
+    ICurveDeposit_2token(__lpOld).remove_liquidity(v1Liquidity, [minToken0Out, minToken1Out]);
+    uint256 amount0 = IERC20(__token0).balanceOf(address(this));
+    uint256 amount1 = IERC20(__token1).balanceOf(address(this));
+    console.log("token0 out:      ", amount0);
+    console.log("token1 out:      ", amount1);
+
+    emit LiquidityRemoved(v1Liquidity, amount0, amount1);
+
+    require(IERC20(__lpOld).balanceOf(address(this)) == 0, "Not all underlying was converted");
+
+    _balancerSwap(__token0, __lpNew, __poolIdNew, amount0, 1);
+    _balancerSwap(__token1, __lpNew, __poolIdNew, amount1, 1);
+    uint256 v2Liquidity = IERC20(__lpNew).balanceOf(address(this));
+    require(v2Liquidity >= minLPNewOut, "Output amount too low");
+    console.log("V2Liquidity:     ", v2Liquidity);
+
+    emit LiquidityProvided(amount0, amount1, v2Liquidity);
+
+    _setUnderlying(__lpNew);
+    require(underlying() == __lpNew, "underlying switch failed");
+    console.log("New underlying:  ", underlying());
+    _setStrategy(__newStrategy);
+    require(strategy() == __newStrategy, "strategy switch failed");
+    console.log("New strategy:    ", strategy());
+
+    // some steps that regular setStrategy does
+    IERC20(underlying()).safeApprove(address(strategy()), 0);
+    IERC20(underlying()).safeApprove(address(strategy()), uint256(~0));
+
+    uint256 token0Left = IERC20(__token0).balanceOf(address(this));
+    if (token0Left > 0) {
+      IERC20(__token0).transfer(strategy(), token0Left);
+    }
+    uint256 token1Left = IERC20(__token1).balanceOf(address(this));
+    if (token1Left > 0) {
+      IERC20(__token1).transfer(__governance, token1Left);
+    }
+
+    emit Migrated(v1Liquidity, v2Liquidity);
+  }
+}

--- a/contracts/base/migration/vaultMigratable_balMaticX.sol
+++ b/contracts/base/migration/vaultMigratable_balMaticX.sol
@@ -17,7 +17,7 @@ contract VaultMigratable_balMaticX is Vault {
   address public constant __lpNew = address(0xb20fC01D21A50d2C734C4a1262B4404d41fA7BF0);
   address public constant __governance = address(0xf00dD244228F51547f0563e60bCa65a30FBF5f7f);
   address public constant __bVault = address(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
-  address public constant __newStrategy = address(0xEC7a197877f8d2dD23E3eC293Cea2146838f1E70);
+  address public constant __newStrategy = address(0x5A42FEDdD5e330AD857A17724543C5ef7FC7C9Cd);
 
   bytes32 public constant __poolIdOld = 0xc17636e36398602dd37bb5d1b3a9008c7629005f0002000000000000000004c4;
   bytes32 public constant __poolIdNew = 0xb20fc01d21a50d2c734c4a1262b4404d41fa7bf000000000000000000000075c;

--- a/contracts/base/migration/vaultMigratable_balMaticX.sol
+++ b/contracts/base/migration/vaultMigratable_balMaticX.sol
@@ -1,0 +1,153 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "../Vault.sol";
+import "../../strategies/balancer/interface/IBVault.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
+import "hardhat/console.sol";
+
+contract VaultMigratable_balMaticX is Vault {
+  using SafeERC20 for IERC20;
+
+  address public constant __wmatic = address(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270);
+  address public constant __maticx = address(0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6);
+  address public constant __lpOld = address(0xC17636e36398602dd37Bb5d1B3a9008c7629005f);
+  address public constant __lpNew = address(0xb20fC01D21A50d2C734C4a1262B4404d41fA7BF0);
+  address public constant __governance = address(0xf00dD244228F51547f0563e60bCa65a30FBF5f7f);
+  address public constant __bVault = address(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
+  address public constant __newStrategy = address(0xEC7a197877f8d2dD23E3eC293Cea2146838f1E70);
+
+  bytes32 public constant __poolIdOld = 0xc17636e36398602dd37bb5d1b3a9008c7629005f0002000000000000000004c4;
+  bytes32 public constant __poolIdNew = 0xb20fc01d21a50d2c734c4a1262b4404d41fa7bf000000000000000000000075c;
+
+  event Migrated(uint256 v1Liquidity, uint256 v2Liquidity);
+  event LiquidityRemoved(uint256 v1Liquidity, uint256 amountToken0, uint256 amountToken1);
+  event LiquidityProvided(uint256 amountToken0, uint256 amountToken1, uint256 v2Liquidity);
+
+  constructor() public {
+  }
+
+  function _approveIfNeed(address token, address spender, uint256 amount) internal {
+    uint256 allowance = IERC20(token).allowance(address(this), spender);
+    if (amount > allowance) {
+      IERC20(token).safeApprove(spender, 0);
+      IERC20(token).safeApprove(spender, amount);
+    }
+  }
+
+  function _balancerWithdraw(
+    bytes32 poolId,
+    uint256 amountIn,
+    uint256[] memory minAmountsOut
+  ) internal {
+    (address[] memory poolTokens,,) = IBVault(__bVault).getPoolTokens(poolId);
+    uint256 _nTokens = poolTokens.length;
+
+    IAsset[] memory assets = new IAsset[](_nTokens);
+    for (uint256 i = 0; i < _nTokens; i++) {
+      assets[i] = IAsset(poolTokens[i]);
+    }
+
+    IBVault.ExitKind exitKind = IBVault.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT;
+    bytes memory userData = abi.encode(exitKind, amountIn);
+
+    IBVault.ExitPoolRequest memory request;
+    request.assets = assets;
+    request.minAmountsOut = minAmountsOut;
+    request.userData = userData;
+
+    IBVault(__bVault).exitPool(
+      poolId,
+      address(this),
+      payable(address(this)),
+      request
+    );
+  }
+
+  function _balancerSwap(
+    address sellToken,
+    address buyToken,
+    bytes32 poolId,
+    uint256 amountIn,
+    uint256 minAmountOut
+  ) internal {
+    IBVault.SingleSwap memory singleSwap;
+    IBVault.SwapKind swapKind = IBVault.SwapKind.GIVEN_IN;
+
+    singleSwap.poolId = poolId;
+    singleSwap.kind = swapKind;
+    singleSwap.assetIn = IAsset(sellToken);
+    singleSwap.assetOut = IAsset(buyToken);
+    singleSwap.amount = amountIn;
+    singleSwap.userData = abi.encode(0);
+
+    IBVault.FundManagement memory funds;
+    funds.sender = address(this);
+    funds.fromInternalBalance = false;
+    funds.recipient = payable(address(this));
+    funds.toInternalBalance = false;
+
+    _approveIfNeed(sellToken, __bVault, amountIn);
+    IBVault(__bVault).swap(singleSwap, funds, minAmountOut, block.timestamp);
+  }
+
+  /**
+  * Migrates the vault from the old MaticX BPT underlying to new MaticX BPT underlying
+  */
+  function migrateUnderlying(
+    uint256 minWMaticOut,
+    uint256 minMaticXOut,
+    uint256 minLPNewOut
+  ) public onlyControllerOrGovernance {
+    require(underlying() == __lpOld, "Can only migrate if the underlying is 2JPY");
+    withdrawAll();
+
+    uint256 v1Liquidity = IERC20(__lpOld).balanceOf(address(this));
+    console.log("V1Liquidity:     ", v1Liquidity);
+    uint256[] memory minOutput = new uint256[](2);
+    minOutput[0] = minWMaticOut;
+    minOutput[1] = minMaticXOut;
+
+    _balancerWithdraw(__poolIdOld, v1Liquidity, minOutput);
+    uint256 amountWMatic = IERC20(__wmatic).balanceOf(address(this));
+    uint256 amountMaticX = IERC20(__maticx).balanceOf(address(this));
+    console.log("WMatic out:      ", amountWMatic);
+    console.log("MaticX out:      ", amountMaticX);
+
+    emit LiquidityRemoved(v1Liquidity, amountWMatic, amountMaticX);
+
+    require(IERC20(__lpOld).balanceOf(address(this)) == 0, "Not all underlying was converted");
+
+    _balancerSwap(__wmatic, __lpNew, __poolIdNew, amountWMatic, 1);
+    _balancerSwap(__maticx, __lpNew, __poolIdNew, amountMaticX, 1);
+    uint256 v2Liquidity = IERC20(__lpNew).balanceOf(address(this));
+    require(v2Liquidity >= minLPNewOut, "Output amount too low");
+    console.log("V2Liquidity:     ", v2Liquidity);
+
+    emit LiquidityProvided(amountWMatic, amountMaticX, v2Liquidity);
+
+    _setUnderlying(__lpNew);
+    require(underlying() == __lpNew, "underlying switch failed");
+    console.log("New underlying:  ", underlying());
+    _setStrategy(__newStrategy);
+    require(strategy() == __newStrategy, "strategy switch failed");
+    console.log("New strategy:    ", strategy());
+
+    // some steps that regular setStrategy does
+    IERC20(underlying()).safeApprove(address(strategy()), 0);
+    IERC20(underlying()).safeApprove(address(strategy()), uint256(~0));
+
+    uint256 wMaticLeft = IERC20(__wmatic).balanceOf(address(this));
+    if (wMaticLeft > 0) {
+      IERC20(__wmatic).transfer(strategy(), wMaticLeft);
+    }
+    uint256 maticXLeft = IERC20(__maticx).balanceOf(address(this));
+    if (maticXLeft > 0) {
+      IERC20(__maticx).transfer(__governance, maticXLeft);
+    }
+
+    emit Migrated(v1Liquidity, v2Liquidity);
+  }
+}

--- a/contracts/base/migration/vaultMigratable_balStMatic.sol
+++ b/contracts/base/migration/vaultMigratable_balStMatic.sol
@@ -1,0 +1,153 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "../Vault.sol";
+import "../../strategies/balancer/interface/IBVault.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
+import "hardhat/console.sol";
+
+contract VaultMigratable_balStMatic is Vault {
+  using SafeERC20 for IERC20;
+
+  address public constant __wmatic = address(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270);
+  address public constant __stmatic = address(0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4);
+  address public constant __lpOld = address(0xaF5E0B5425dE1F5a630A8cB5AA9D97B8141C908D);
+  address public constant __lpNew = address(0x8159462d255C1D24915CB51ec361F700174cD994);
+  address public constant __governance = address(0xf00dD244228F51547f0563e60bCa65a30FBF5f7f);
+  address public constant __bVault = address(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
+  address public constant __newStrategy = address(0xEC7a197877f8d2dD23E3eC293Cea2146838f1E70);
+
+  bytes32 public constant __poolIdOld = 0xaf5e0b5425de1f5a630a8cb5aa9d97b8141c908d000200000000000000000366;
+  bytes32 public constant __poolIdNew = 0x8159462d255c1d24915cb51ec361f700174cd99400000000000000000000075d;
+
+  event Migrated(uint256 v1Liquidity, uint256 v2Liquidity);
+  event LiquidityRemoved(uint256 v1Liquidity, uint256 amountToken0, uint256 amountToken1);
+  event LiquidityProvided(uint256 amountToken0, uint256 amountToken1, uint256 v2Liquidity);
+
+  constructor() public {
+  }
+
+  function _approveIfNeed(address token, address spender, uint256 amount) internal {
+    uint256 allowance = IERC20(token).allowance(address(this), spender);
+    if (amount > allowance) {
+      IERC20(token).safeApprove(spender, 0);
+      IERC20(token).safeApprove(spender, amount);
+    }
+  }
+
+  function _balancerWithdraw(
+    bytes32 poolId,
+    uint256 amountIn,
+    uint256[] memory minAmountsOut
+  ) internal {
+    (address[] memory poolTokens,,) = IBVault(__bVault).getPoolTokens(poolId);
+    uint256 _nTokens = poolTokens.length;
+
+    IAsset[] memory assets = new IAsset[](_nTokens);
+    for (uint256 i = 0; i < _nTokens; i++) {
+      assets[i] = IAsset(poolTokens[i]);
+    }
+
+    IBVault.ExitKind exitKind = IBVault.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT;
+    bytes memory userData = abi.encode(exitKind, amountIn);
+
+    IBVault.ExitPoolRequest memory request;
+    request.assets = assets;
+    request.minAmountsOut = minAmountsOut;
+    request.userData = userData;
+
+    IBVault(__bVault).exitPool(
+      poolId,
+      address(this),
+      payable(address(this)),
+      request
+    );
+  }
+
+  function _balancerSwap(
+    address sellToken,
+    address buyToken,
+    bytes32 poolId,
+    uint256 amountIn,
+    uint256 minAmountOut
+  ) internal {
+    IBVault.SingleSwap memory singleSwap;
+    IBVault.SwapKind swapKind = IBVault.SwapKind.GIVEN_IN;
+
+    singleSwap.poolId = poolId;
+    singleSwap.kind = swapKind;
+    singleSwap.assetIn = IAsset(sellToken);
+    singleSwap.assetOut = IAsset(buyToken);
+    singleSwap.amount = amountIn;
+    singleSwap.userData = abi.encode(0);
+
+    IBVault.FundManagement memory funds;
+    funds.sender = address(this);
+    funds.fromInternalBalance = false;
+    funds.recipient = payable(address(this));
+    funds.toInternalBalance = false;
+
+    _approveIfNeed(sellToken, __bVault, amountIn);
+    IBVault(__bVault).swap(singleSwap, funds, minAmountOut, block.timestamp);
+  }
+
+  /**
+  * Migrates the vault from the old MaticX BPT underlying to new MaticX BPT underlying
+  */
+  function migrateUnderlying(
+    uint256 minWMaticOut,
+    uint256 minStMaticOut,
+    uint256 minLPNewOut
+  ) public onlyControllerOrGovernance {
+    require(underlying() == __lpOld, "Can only migrate if the underlying is 2JPY");
+    withdrawAll();
+
+    uint256 v1Liquidity = IERC20(__lpOld).balanceOf(address(this));
+    console.log("V1Liquidity:     ", v1Liquidity);
+    uint256[] memory minOutput = new uint256[](2);
+    minOutput[0] = minWMaticOut;
+    minOutput[1] = minStMaticOut;
+
+    _balancerWithdraw(__poolIdOld, v1Liquidity, minOutput);
+    uint256 amountWMatic = IERC20(__wmatic).balanceOf(address(this));
+    uint256 amountStMatic = IERC20(__stmatic).balanceOf(address(this));
+    console.log("WMatic out:      ", amountWMatic);
+    console.log("stMatic out:     ", amountStMatic);
+
+    emit LiquidityRemoved(v1Liquidity, amountWMatic, amountStMatic);
+
+    require(IERC20(__lpOld).balanceOf(address(this)) == 0, "Not all underlying was converted");
+
+    _balancerSwap(__wmatic, __lpNew, __poolIdNew, amountWMatic, 1);
+    _balancerSwap(__stmatic, __lpNew, __poolIdNew, amountStMatic, 1);
+    uint256 v2Liquidity = IERC20(__lpNew).balanceOf(address(this));
+    require(v2Liquidity >= minLPNewOut, "Output amount too low");
+    console.log("V2Liquidity:     ", v2Liquidity);
+
+    emit LiquidityProvided(amountWMatic, amountStMatic, v2Liquidity);
+
+    _setUnderlying(__lpNew);
+    require(underlying() == __lpNew, "underlying switch failed");
+    console.log("New underlying:  ", underlying());
+    _setStrategy(__newStrategy);
+    require(strategy() == __newStrategy, "strategy switch failed");
+    console.log("New strategy:    ", strategy());
+
+    // some steps that regular setStrategy does
+    IERC20(underlying()).safeApprove(address(strategy()), 0);
+    IERC20(underlying()).safeApprove(address(strategy()), uint256(~0));
+
+    uint256 wMaticLeft = IERC20(__wmatic).balanceOf(address(this));
+    if (wMaticLeft > 0) {
+      IERC20(__wmatic).transfer(strategy(), wMaticLeft);
+    }
+    uint256 stMaticLeft = IERC20(__stmatic).balanceOf(address(this));
+    if (stMaticLeft > 0) {
+      IERC20(__stmatic).transfer(__governance, stMaticLeft);
+    }
+
+    emit Migrated(v1Liquidity, v2Liquidity);
+  }
+}

--- a/contracts/base/migration/vaultMigratable_balStMatic.sol
+++ b/contracts/base/migration/vaultMigratable_balStMatic.sol
@@ -17,7 +17,7 @@ contract VaultMigratable_balStMatic is Vault {
   address public constant __lpNew = address(0x8159462d255C1D24915CB51ec361F700174cD994);
   address public constant __governance = address(0xf00dD244228F51547f0563e60bCa65a30FBF5f7f);
   address public constant __bVault = address(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
-  address public constant __newStrategy = address(0xEC7a197877f8d2dD23E3eC293Cea2146838f1E70);
+  address public constant __newStrategy = address(0x9674AdE8257BEeC0f8c6fbdEAE279EA92543D989);
 
   bytes32 public constant __poolIdOld = 0xaf5e0b5425de1f5a630a8cb5aa9d97b8141c908d000200000000000000000366;
   bytes32 public constant __poolIdNew = 0x8159462d255c1d24915cb51ec361f700174cd99400000000000000000000075d;

--- a/contracts/strategies/balancer/BalancerStrategyV3.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV3.sol
@@ -1,0 +1,506 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/math/Math.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "../../base/interface/uniswap/IUniswapV2Router02.sol";
+import "../../base/interface/IVault.sol";
+import "../../base/upgradability/BaseUpgradeableStrategy.sol";
+import "../../base/interface/uniswap/IUniswapV2Pair.sol";
+import "./interface/IBVault.sol";
+import "../../base/interface/curve/Gauge.sol";
+
+contract BalancerStrategyV3 is BaseUpgradeableStrategy {
+
+  using SafeMath for uint256;
+  using SafeERC20 for IERC20;
+
+  address public constant weth = address(0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619);
+  address public constant quickswapRouterV2 = address(0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff);
+
+  // additional storage slots (on top of BaseUpgradeableStrategy ones) are defined here
+  bytes32 internal constant _POOLID_SLOT = 0x3fd729bfa2e28b7806b03a6e014729f59477b530f995be4d51defc9dad94810b;
+  bytes32 internal constant _BVAULT_SLOT = 0x85cbd475ba105ca98d9a2db62dcf7cf3c0074b36303ef64160d68a3e0fdd3c67;
+  bytes32 internal constant _DEPOSIT_TOKEN_SLOT = 0x219270253dbc530471c88a9e7c321b36afda219583431e7b6c386d2d46e70c86;
+  bytes32 internal constant _BOOSTED_POOL = 0xd816e748a078d825fa9cc9dc9335909f9baa20dc1b5619211972fc7e672bd2fb;
+
+  // this would be reset on each upgrade
+  address[] public WETH2deposit;
+  mapping(address => address[]) public reward2WETH;
+  mapping(address => mapping(address => bytes32)) public poolIds;
+  address[] public rewardTokens;
+  mapping(address => mapping(address => bool)) public deposit;
+
+  constructor() public BaseUpgradeableStrategy() {
+    assert(_POOLID_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.poolId")) - 1));
+    assert(_BVAULT_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.bVault")) - 1));
+    assert(_DEPOSIT_TOKEN_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.depositToken")) - 1));
+    assert(_BOOSTED_POOL == bytes32(uint256(keccak256("eip1967.strategyStorage.boostedPool")) - 1));
+  }
+
+  function initializeBaseStrategy(
+    address _storage,
+    address _underlying,
+    address _vault,
+    address _rewardPool,
+    address _bVault,
+    bytes32 _poolID,
+    address _depositToken,
+    bool _boosted
+  ) public initializer {
+
+    BaseUpgradeableStrategy.initialize(
+      _storage,
+      _underlying,
+      _vault,
+      _rewardPool,
+      weth,
+      80, // profit sharing numerator
+      1000, // profit sharing denominator
+      true, // sell
+      0, // sell floor
+      12 hours // implementation change delay
+    );
+
+    (address _lpt,) = IBVault(_bVault).getPool(_poolID);
+    require(_lpt == _underlying, "Underlying mismatch");
+
+    _setPoolId(_poolID);
+    _setBVault(_bVault);
+    _setDepositToken(_depositToken);
+    _setBoostedPool(_boosted);
+  }
+
+  function depositArbCheck() public pure returns(bool) {
+    return true;
+  }
+
+  function _rewardPoolBalance() internal view returns (uint256 balance) {
+      balance = Gauge(rewardPool()).balanceOf(address(this));
+  }
+
+  function _emergencyExitRewardPool() internal {
+    uint256 stakedBalance = _rewardPoolBalance();
+    if (stakedBalance != 0) {
+        _withdrawUnderlyingFromPool(stakedBalance);
+    }
+  }
+
+  function _withdrawUnderlyingFromPool(uint256 amount) internal {
+    address rewardPool_ = rewardPool();
+    Gauge(rewardPool_).withdraw(
+      Math.min(Gauge(rewardPool_).balanceOf(address(this)), amount)
+    );
+  }
+
+  function _enterRewardPool() internal {
+    address underlying_ = underlying();
+    address rewardPool_ = rewardPool();
+    uint256 entireBalance = IERC20(underlying_).balanceOf(address(this));
+    IERC20(underlying_).safeApprove(rewardPool_, 0);
+    IERC20(underlying_).safeApprove(rewardPool_, entireBalance);
+    Gauge(rewardPool_).deposit(entireBalance);
+  }
+
+  function _investAllUnderlying() internal onlyNotPausedInvesting {
+    // this check is needed, because most of the SNX reward pools will revert if
+    // you try to stake(0).
+    if(IERC20(underlying()).balanceOf(address(this)) > 0) {
+      _enterRewardPool();
+    }
+  }
+
+  /*
+  *   In case there are some issues discovered about the pool or underlying asset
+  *   Governance can exit the pool properly
+  *   The function is only used for emergency to exit the pool
+  */
+  function emergencyExit() public onlyGovernance {
+    _emergencyExitRewardPool();
+    _setPausedInvesting(true);
+  }
+
+  /*
+  *   Resumes the ability to invest into the underlying reward pools
+  */
+  function continueInvesting() public onlyGovernance {
+    _setPausedInvesting(false);
+  }
+
+  function unsalvagableTokens(address token) public view returns (bool) {
+    return (token == rewardToken() || token == underlying());
+  }
+
+  function setDepositLiquidationPath(address [] memory _route) public onlyGovernance {
+    require(_route[0] == weth, "Path should start with WETH");
+    require(_route[_route.length-1] == depositToken(), "Path should end with depositToken");
+    WETH2deposit = _route;
+  }
+
+  function setRewardLiquidationPath(address [] memory _route) public onlyGovernance {
+    require(_route[_route.length-1] == weth, "Path should end with WETH");
+    bool isReward = false;
+    for(uint256 i = 0; i < rewardTokens.length; i++){
+      if (_route[0] == rewardTokens[i]) {
+        isReward = true;
+      }
+    }
+    require(isReward, "Path should start with a rewardToken");
+    reward2WETH[_route[0]] = _route;
+  }
+
+  function addRewardToken(address _token, address[] memory _path2WETH) public onlyGovernance {
+    rewardTokens.push(_token);
+    setRewardLiquidationPath(_path2WETH);
+  }
+
+  function changeDepositToken(address _depositToken, address[] memory _liquidationPath) public onlyGovernance {
+    _setDepositToken(_depositToken);
+    setDepositLiquidationPath(_liquidationPath);
+  }
+
+  function setBalancerSwapPoolId(address _sellToken, address _buyToken, bytes32 _poolId) public onlyGovernance {
+    poolIds[_sellToken][_buyToken] = _poolId;
+  }
+
+  function _approveIfNeed(address token, address spender, uint256 amount) internal {
+    uint256 allowance = IERC20(token).allowance(address(this), spender);
+    if (amount > allowance) {
+      IERC20(token).safeApprove(spender, 0);
+      IERC20(token).safeApprove(spender, amount);
+    }
+  }
+
+  function _quickSwap(
+    address sellToken,
+    address buyToken,
+    uint256 amountIn,
+    uint256 minAmountOut
+  ) internal {
+    address[] memory path = new address[](2);
+    path[0] = sellToken;
+    path[1] = buyToken;
+    IERC20(sellToken).safeApprove(quickswapRouterV2, 0);
+    IERC20(sellToken).safeApprove(quickswapRouterV2, amountIn);
+    // we can accept 1 as the minimum because this will be called only by a trusted worker
+    IUniswapV2Router02(quickswapRouterV2).swapExactTokensForTokens(
+      amountIn, minAmountOut, path, address(this), block.timestamp
+    );
+  }
+
+  function _balancerSwap(
+    address sellToken,
+    address buyToken,
+    bytes32 poolId,
+    uint256 amountIn,
+    uint256 minAmountOut
+  ) internal {
+    address _bVault = bVault();
+    IBVault.SingleSwap memory singleSwap;
+    IBVault.SwapKind swapKind = IBVault.SwapKind.GIVEN_IN;
+
+    singleSwap.poolId = poolId;
+    singleSwap.kind = swapKind;
+    singleSwap.assetIn = IAsset(sellToken);
+    singleSwap.assetOut = IAsset(buyToken);
+    singleSwap.amount = amountIn;
+    singleSwap.userData = abi.encode(0);
+
+    IBVault.FundManagement memory funds;
+    funds.sender = address(this);
+    funds.fromInternalBalance = false;
+    funds.recipient = payable(address(this));
+    funds.toInternalBalance = false;
+
+    _approveIfNeed(sellToken, _bVault, amountIn);
+    IBVault(_bVault).swap(singleSwap, funds, minAmountOut, block.timestamp);
+  }
+
+  function _balancerDeposit(
+    address tokenIn,
+    bytes32 poolId,
+    uint256 amountIn,
+    uint256 minAmountOut
+  ) internal {
+    address _bVault = bVault();
+    (address[] memory poolTokens,,) = IBVault(_bVault).getPoolTokens(poolId);
+    uint256 _nTokens = poolTokens.length;
+
+    IAsset[] memory assets = new IAsset[](_nTokens);
+    for (uint256 i = 0; i < _nTokens; i++) {
+      assets[i] = IAsset(poolTokens[i]);
+    }
+
+    IBVault.JoinKind joinKind = IBVault.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT;
+
+    uint256[] memory amountsIn = new uint256[](_nTokens);
+    for (uint256 j = 0; j < amountsIn.length; j++) {
+      amountsIn[j] = address(assets[j]) == tokenIn ? amountIn : 0;
+    }
+
+    bytes memory userData = abi.encode(joinKind, amountsIn, minAmountOut);
+
+    IBVault.JoinPoolRequest memory request;
+    request.assets = assets;
+    request.maxAmountsIn = amountsIn;
+    request.userData = userData;
+    request.fromInternalBalance = false;
+
+    _approveIfNeed(tokenIn, _bVault, amountIn);
+    IBVault(_bVault).joinPool(
+      poolId,
+      address(this),
+      address(this),
+      request
+    );
+  }
+
+  function _liquidateReward() internal {
+    if (!sell()) {
+      // Profits can be disabled for possible simplified and rapid exit
+      emit ProfitsNotCollected(sell(), false);
+      return;
+    }
+
+    for(uint256 i = 0; i < rewardTokens.length; i++){
+      address token = rewardTokens[i];
+      uint256 rewardBalance = IERC20(token).balanceOf(address(this));
+
+      if (rewardBalance == 0) {
+        continue;
+      }
+      if (reward2WETH[token].length < 2) {
+        continue;
+      }
+      for (uint256 j = 0; j < reward2WETH[token].length - 1; j++) {
+        address sellToken = reward2WETH[token][j];
+        address buyToken = reward2WETH[token][j+1];
+        uint256 sellTokenBalance = IERC20(sellToken).balanceOf(address(this));
+        if (poolIds[sellToken][buyToken] == bytes32(0)) {
+          _quickSwap(sellToken, buyToken, sellTokenBalance, 1);
+        } else {
+          if (deposit[sellToken][buyToken]) {
+            _balancerDeposit(
+              sellToken,
+              poolIds[sellToken][buyToken],
+              sellTokenBalance,
+              1
+            );
+          } else {
+            _balancerSwap(
+              sellToken,
+              buyToken,
+              poolIds[sellToken][buyToken],
+              sellTokenBalance,
+              1
+            );
+          }
+        }
+      }
+    }
+
+    address _rewardToken = rewardToken();
+    uint256 rewardBalance = IERC20(_rewardToken).balanceOf(address(this));
+    notifyProfitInRewardToken(rewardBalance);
+    uint256 remainingRewardBalance = IERC20(_rewardToken).balanceOf(address(this));
+
+    if (remainingRewardBalance == 0) {
+      return;
+    }
+
+    if (WETH2deposit.length > 1) { //else we assume WETH is the deposit token, no need to swap
+      for(uint256 i = 0; i < WETH2deposit.length - 1; i++){
+        address sellToken = WETH2deposit[i];
+        address buyToken = WETH2deposit[i+1];
+        uint256 sellTokenBalance = IERC20(sellToken).balanceOf(address(this));
+        if (poolIds[sellToken][buyToken] == bytes32(0)) {
+          _quickSwap(sellToken, buyToken, sellTokenBalance, 1);
+        } else {
+          if (deposit[sellToken][buyToken]) {
+            _balancerDeposit(
+              sellToken,
+              poolIds[sellToken][buyToken],
+              sellTokenBalance,
+              1
+            );
+          } else {
+            _balancerSwap(
+              sellToken,
+              buyToken,
+              poolIds[sellToken][buyToken],
+              sellTokenBalance,
+              1
+            );
+          }
+        }
+      }
+    }
+
+    address _depositToken = depositToken();
+    uint256 tokenBalance = IERC20(depositToken()).balanceOf(address(this));
+    if (tokenBalance > 0 && !(_depositToken == underlying())) {
+      depositLP();
+    }
+  }
+
+  function depositLP() internal {
+    address _depositToken = depositToken();
+    bytes32 _poolId = poolId();
+    uint256 depositTokenBalance = IERC20(_depositToken).balanceOf(address(this));
+
+    if (boostedPool()) {
+      _balancerSwap(
+        _depositToken,
+        underlying(),
+        _poolId,
+        depositTokenBalance,
+        1
+      );
+    } else {
+      _balancerDeposit(
+        _depositToken,
+        _poolId,
+        depositTokenBalance,
+        1
+      );
+    }
+  }
+
+  /*
+  *   Withdraws all the asset to the vault
+  */
+  function withdrawAllToVault() public restricted {
+    _withdrawUnderlyingFromPool(_rewardPoolBalance());
+    _liquidateReward();
+    address underlying_ = underlying();
+    IERC20(underlying_).safeTransfer(vault(), IERC20(underlying_).balanceOf(address(this)));
+  }
+
+  /*
+  *   Withdraws all the asset to the vault
+  */
+  function withdrawToVault(uint256 _amount) public restricted {
+    // Typically there wouldn't be any amount here
+    // however, it is possible because of the emergencyExit
+    address underlying_ = underlying();
+    uint256 entireBalance = IERC20(underlying_).balanceOf(address(this));
+
+    if(_amount > entireBalance){
+      // While we have the check above, we still using SafeMath below
+      // for the peace of mind (in case something gets changed in between)
+      uint256 needToWithdraw = _amount.sub(entireBalance);
+      uint256 toWithdraw = Math.min(_rewardPoolBalance(), needToWithdraw);
+      _withdrawUnderlyingFromPool(toWithdraw);
+    }
+    IERC20(underlying_).safeTransfer(vault(), _amount);
+  }
+
+  /*
+  *   Note that we currently do not have a mechanism here to include the
+  *   amount of reward that is accrued.
+  */
+  function investedUnderlyingBalance() external view returns (uint256) {
+    if (rewardPool() == address(0)) {
+      return IERC20(underlying()).balanceOf(address(this));
+    }
+    // Adding the amount locked in the reward pool and the amount that is somehow in this contract
+    // both are in the units of "underlying"
+    // The second part is needed because there is the emergency exit mechanism
+    // which would break the assumption that all the funds are always inside of the reward pool
+    return _rewardPoolBalance().add(IERC20(underlying()).balanceOf(address(this)));
+  }
+
+  /*
+  *   Governance or Controller can claim coins that are somehow transferred into the contract
+  *   Note that they cannot come in take away coins that are used and defined in the strategy itself
+  */
+  function salvage(address recipient, address token, uint256 amount) external onlyControllerOrGovernance {
+     // To make sure that governance cannot come in and take away the coins
+    require(!unsalvagableTokens(token), "token is defined as not salvagable");
+    IERC20(token).safeTransfer(recipient, amount);
+  }
+
+  /*
+  *   Get the reward, sell it in exchange for underlying, invest what you got.
+  *   It's not much, but it's honest work.
+  *
+  *   Note that although `onlyNotPausedInvesting` is not added here,
+  *   calling `investAllUnderlying()` affectively blocks the usage of `doHardWork`
+  *   when the investing is being paused by governance.
+  */
+  function doHardWork() external onlyNotPausedInvesting restricted {
+    Gauge(rewardPool()).claim_rewards();
+    _liquidateReward();
+    _investAllUnderlying();
+  }
+
+  /**
+  * Can completely disable claiming UNI rewards and selling. Good for emergency withdraw in the
+  * simplest possible way.
+  */
+  function setSell(bool s) public onlyGovernance {
+    _setSell(s);
+  }
+
+  /**
+  * Sets the minimum amount of CRV needed to trigger a sale.
+  */
+  function setSellFloor(uint256 floor) public onlyGovernance {
+    _setSellFloor(floor);
+  }
+
+  // masterchef rewards pool ID
+  function _setPoolId(bytes32 _value) internal {
+    setBytes32(_POOLID_SLOT, _value);
+  }
+
+  function poolId() public view returns (bytes32) {
+    return getBytes32(_POOLID_SLOT);
+  }
+
+  function _setBVault(address _address) internal {
+    setAddress(_BVAULT_SLOT, _address);
+  }
+
+  function bVault() public view returns (address) {
+    return getAddress(_BVAULT_SLOT);
+  }
+
+  function _setDepositToken(address _address) internal {
+    setAddress(_DEPOSIT_TOKEN_SLOT, _address);
+  }
+
+  function depositToken() public view returns (address) {
+    return getAddress(_DEPOSIT_TOKEN_SLOT);
+  }
+
+  function _setBoostedPool(bool _boosted) internal {
+    setBoolean(_BOOSTED_POOL, _boosted);
+  }
+
+  function boostedPool() public view returns (bool) {
+    return getBoolean(_BOOSTED_POOL);
+  }
+
+  function setBytes32(bytes32 slot, bytes32 _value) internal {
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      sstore(slot, _value)
+    }
+  }
+
+  function getBytes32(bytes32 slot) internal view returns (bytes32 str) {
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      str := sload(slot)
+    }
+  }
+
+  function finalizeUpgrade() external onlyGovernance {
+    _finalizeUpgrade();
+  }
+
+  receive() external payable {} // this is needed for the receiving Matic
+}

--- a/contracts/strategies/balancer/BalancerStrategyV3Mainnet_2BRL.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV3Mainnet_2BRL.sol
@@ -1,0 +1,39 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./BalancerStrategyV3.sol";
+
+contract BalancerStrategyV3Mainnet_2BRL is BalancerStrategyV3 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xE22483774bd8611bE2Ad2F4194078DaC9159F4bA);
+    address bbamusd = address(0x48e6B98ef6329f8f0A30eBB8c7C960330d648085);
+    address bal = address(0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3);
+    address bbamdai = address(0x178E029173417b1F9C8bC16DCeC6f697bC323746);
+    address dai = address(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063);
+    address gauge = address(0xbDb8DA6156722a3D583ee679988B35cacCd86BC3);
+    BalancerStrategyV3.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      gauge,
+      address(0xBA12222222228d8Ba445958a75a0704d566BF2C8), //balancer vault
+      0xe22483774bd8611be2ad2f4194078dac9159f4ba0000000000000000000008f0,  // Pool id
+      underlying,   //depositToken
+      true      //boosted
+    );
+    rewardTokens = [bal];
+    reward2WETH[bal] = [bal, weth];
+    WETH2deposit = [weth, dai, bbamdai, bbamusd, underlying];
+    poolIds[bal][weth] = 0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f000200000000000000000426;
+    poolIds[dai][bbamdai] = 0x178e029173417b1f9c8bc16dcec6f697bc323746000000000000000000000758;
+    poolIds[bbamdai][bbamusd] = 0x48e6b98ef6329f8f0a30ebb8c7c960330d64808500000000000000000000075b;
+    poolIds[bbamusd][underlying] = 0x4a0b73f0d13ff6d43e304a174697e3d5cfd310a400020000000000000000091c;
+  }
+}

--- a/contracts/strategies/balancer/BalancerStrategyV3Mainnet_2BRLUSD.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV3Mainnet_2BRLUSD.sol
@@ -1,0 +1,38 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./BalancerStrategyV3.sol";
+
+contract BalancerStrategyV3Mainnet_2BRLUSD is BalancerStrategyV3 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0x4A0b73f0D13fF6d43e304a174697e3d5CFd310a4);
+    address bbamusd = address(0x48e6B98ef6329f8f0A30eBB8c7C960330d648085);
+    address bal = address(0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3);
+    address bbamdai = address(0x178E029173417b1F9C8bC16DCeC6f697bC323746);
+    address dai = address(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063);
+    address gauge = address(0x75108A554A34BB2846ABfb00D889BFD0Bb34E1d6);
+    BalancerStrategyV3.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      gauge,
+      address(0xBA12222222228d8Ba445958a75a0704d566BF2C8), //balancer vault
+      0x4a0b73f0d13ff6d43e304a174697e3d5cfd310a400020000000000000000091c,  // Pool id
+      bbamusd,   //depositToken
+      false      //boosted
+    );
+    rewardTokens = [bal];
+    reward2WETH[bal] = [bal, weth];
+    WETH2deposit = [weth, dai, bbamdai, bbamusd];
+    poolIds[bal][weth] = 0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f000200000000000000000426;
+    poolIds[dai][bbamdai] = 0x178e029173417b1f9c8bc16dcec6f697bc323746000000000000000000000758;
+    poolIds[bbamdai][bbamusd] = 0x48e6b98ef6329f8f0a30ebb8c7c960330d64808500000000000000000000075b;
+  }
+}

--- a/contracts/strategies/balancer/BalancerStrategyV3Mainnet_2EUR_PAR.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV3Mainnet_2EUR_PAR.sol
@@ -15,7 +15,7 @@ contract BalancerStrategyV3Mainnet_2EUR_PAR is BalancerStrategyV3 {
     address underlying = address(0x7d60a4Cb5cA92E2Da965637025122296ea6854f9);
     address jeur = address(0x4e3Decbb3645551B8A19f0eA1678079FCB33fB4c);
     address bal = address(0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3);
-    address gauge = address(0x0000000000000000000000000000000000000000);
+    address gauge = address(0xD14875e2C65A46d15501C9296A9bCC0E17510978);
     BalancerStrategyV3.initializeBaseStrategy(
       _storage,
       underlying,

--- a/contracts/strategies/balancer/BalancerStrategyV3Mainnet_2EUR_PAR.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV3Mainnet_2EUR_PAR.sol
@@ -1,0 +1,34 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./BalancerStrategyV3.sol";
+
+contract BalancerStrategyV3Mainnet_2EUR_PAR is BalancerStrategyV3 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0x7d60a4Cb5cA92E2Da965637025122296ea6854f9);
+    address jeur = address(0x4e3Decbb3645551B8A19f0eA1678079FCB33fB4c);
+    address bal = address(0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3);
+    address gauge = address(0x0000000000000000000000000000000000000000);
+    BalancerStrategyV3.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      gauge,
+      address(0xBA12222222228d8Ba445958a75a0704d566BF2C8), //balancer vault
+      0x7d60a4cb5ca92e2da965637025122296ea6854f900000000000000000000085e,  // Pool id
+      jeur,   //depositToken
+      true      //boosted
+    );
+    rewardTokens = [bal];
+    reward2WETH[bal] = [bal, weth];
+    WETH2deposit = [weth, jeur];
+    poolIds[bal][weth] = 0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f000200000000000000000426;
+  }
+}

--- a/contracts/strategies/balancer/BalancerStrategyV3Mainnet_2EUR_agEUR.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV3Mainnet_2EUR_agEUR.sol
@@ -1,0 +1,34 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./BalancerStrategyV3.sol";
+
+contract BalancerStrategyV3Mainnet_2EUR_agEUR is BalancerStrategyV3 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xa48D164F6eB0EDC68bd03B56fa59E12F24499aD1);
+    address jeur = address(0x4e3Decbb3645551B8A19f0eA1678079FCB33fB4c);
+    address bal = address(0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3);
+    address gauge = address(0x0000000000000000000000000000000000000000);
+    BalancerStrategyV3.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      gauge,
+      address(0xBA12222222228d8Ba445958a75a0704d566BF2C8), //balancer vault
+      0xa48d164f6eb0edc68bd03b56fa59e12f24499ad10000000000000000000007c4,  // Pool id
+      jeur,   //depositToken
+      true      //boosted
+    );
+    rewardTokens = [bal];
+    reward2WETH[bal] = [bal, weth];
+    WETH2deposit = [weth, jeur];
+    poolIds[bal][weth] = 0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f000200000000000000000426;
+  }
+}

--- a/contracts/strategies/balancer/BalancerStrategyV3Mainnet_2EUR_agEUR.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV3Mainnet_2EUR_agEUR.sol
@@ -15,7 +15,7 @@ contract BalancerStrategyV3Mainnet_2EUR_agEUR is BalancerStrategyV3 {
     address underlying = address(0xa48D164F6eB0EDC68bd03B56fa59E12F24499aD1);
     address jeur = address(0x4e3Decbb3645551B8A19f0eA1678079FCB33fB4c);
     address bal = address(0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3);
-    address gauge = address(0x0000000000000000000000000000000000000000);
+    address gauge = address(0x8c73C7A998F54e3A936885C752c9955c78A5Febb);
     BalancerStrategyV3.initializeBaseStrategy(
       _storage,
       underlying,

--- a/contracts/strategies/balancer/BalancerStrategyV3Mainnet_MaticX.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV3Mainnet_MaticX.sol
@@ -1,0 +1,37 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./BalancerStrategyV3.sol";
+
+contract BalancerStrategyV3Mainnet_MaticX is BalancerStrategyV3 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xb20fC01D21A50d2C734C4a1262B4404d41fA7BF0);
+    address wmatic = address(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270);
+    address bal = address(0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3);
+    address sd = address(0x1d734A02eF1e1f5886e66b0673b71Af5B53ffA94);
+    address usdc = address(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
+    address gauge = address(0xdFFe97094394680362Ec9706a759eB9366d804C2);
+    BalancerStrategyV3.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      gauge,
+      address(0xBA12222222228d8Ba445958a75a0704d566BF2C8), //balancer vault
+      0xb20fc01d21a50d2c734c4a1262b4404d41fa7bf000000000000000000000075c,  // Pool id
+      wmatic,   //depositToken
+      true      //boosted
+    );
+    rewardTokens = [bal, sd];
+    reward2WETH[bal] = [bal, weth];
+    reward2WETH[sd] = [sd, usdc, weth];
+    WETH2deposit = [weth, wmatic];
+    poolIds[bal][weth] = 0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f000200000000000000000426;
+  }
+}

--- a/contracts/strategies/balancer/BalancerStrategyV3Mainnet_bbamusd.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV3Mainnet_bbamusd.sol
@@ -1,0 +1,36 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./BalancerStrategyV3.sol";
+
+contract BalancerStrategyV3Mainnet_bbamusd is BalancerStrategyV3 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0x48e6B98ef6329f8f0A30eBB8c7C960330d648085);
+    address bbamdai = address(0x178E029173417b1F9C8bC16DCeC6f697bC323746);
+    address bal = address(0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3);
+    address dai = address(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063);
+    address gauge = address(0x1c514fEc643AdD86aeF0ef14F4add28cC3425306);
+    BalancerStrategyV3.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      gauge,
+      address(0xBA12222222228d8Ba445958a75a0704d566BF2C8), //balancer vault
+      0x48e6b98ef6329f8f0a30ebb8c7c960330d64808500000000000000000000075b,  // Pool id
+      bbamdai,   //depositToken
+      true      //boosted
+    );
+    rewardTokens = [bal];
+    reward2WETH[bal] = [bal, weth];
+    WETH2deposit = [weth, dai, bbamdai];
+    poolIds[bal][weth] = 0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f000200000000000000000426;
+    poolIds[dai][bbamdai] = 0x178e029173417b1f9c8bc16dcec6f697bc323746000000000000000000000758;
+  }
+}

--- a/contracts/strategies/balancer/BalancerStrategyV3Mainnet_stMatic.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV3Mainnet_stMatic.sol
@@ -1,0 +1,36 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./BalancerStrategyV3.sol";
+
+contract BalancerStrategyV3Mainnet_stMatic is BalancerStrategyV3 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0x8159462d255C1D24915CB51ec361F700174cD994);
+    address wmatic = address(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270);
+    address bal = address(0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3);
+    address ldo = address(0xC3C7d422809852031b44ab29EEC9F1EfF2A58756);
+    address gauge = address(0x2Aa6fB79EfE19A3fcE71c46AE48EFc16372ED6dD);
+    BalancerStrategyV3.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      gauge,
+      address(0xBA12222222228d8Ba445958a75a0704d566BF2C8), //balancer vault
+      0x8159462d255c1d24915cb51ec361f700174cd99400000000000000000000075d,  // Pool id
+      wmatic,   //depositToken
+      true      //boosted
+    );
+    rewardTokens = [bal, ldo];
+    reward2WETH[bal] = [bal, weth];
+    reward2WETH[ldo] = [ldo, wmatic, weth];
+    WETH2deposit = [weth, wmatic];
+    poolIds[bal][weth] = 0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f000200000000000000000426;
+  }
+}

--- a/contracts/strategies/balancer/BalancerStrategyV3Mainnet_tetuBal.sol
+++ b/contracts/strategies/balancer/BalancerStrategyV3Mainnet_tetuBal.sol
@@ -1,0 +1,36 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./BalancerStrategyV3.sol";
+
+contract BalancerStrategyV3Mainnet_tetuBal is BalancerStrategyV3 {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xB797AdfB7b268faeaA90CAdBfEd464C76ee599Cd);
+    address wethBal = address(0x3d468AB2329F296e1b9d8476Bb54Dd77D8c2320f);
+    address bal = address(0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3);
+    address gauge = address(0xAA59736b80cf77d1E7D56B7bbA5A8050805F5064);
+    BalancerStrategyV3.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      gauge,
+      address(0xBA12222222228d8Ba445958a75a0704d566BF2C8), //balancer vault
+      0xb797adfb7b268faeaa90cadbfed464c76ee599cd0002000000000000000005ba,  // Pool id
+      wethBal,   //depositToken
+      false      //boosted
+    );
+    rewardTokens = [bal];
+    reward2WETH[bal] = [bal, weth];
+    WETH2deposit = [weth, wethBal];
+    poolIds[bal][weth] = 0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f000200000000000000000426;
+    poolIds[weth][wethBal] = 0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f000200000000000000000426;
+    deposit[weth][wethBal] = true;
+  }
+}

--- a/contracts/strategies/balancer/interface/IBVault.sol
+++ b/contracts/strategies/balancer/interface/IBVault.sol
@@ -238,7 +238,7 @@ interface IBVault {
         external
         view
         returns (
-            IERC20[] memory tokens,
+            address[] memory tokens,
             uint256[] memory balances,
             uint256 lastChangeBlock
         );

--- a/test/balancer/2brl_v3.js
+++ b/test/balancer/2brl_v3.js
@@ -1,0 +1,123 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+} = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("IERC20");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("BalancerStrategyV3Mainnet_2BRL");
+
+// Developed and tested at blockNumber 38270720
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Polygon Mainnet Balancer 2BRL V3", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x685723B9dC89BDF28BA5F98F9A8c0aC899bD6E77";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xE22483774bd8611bE2Ad2F4194078DaC9159F4bA");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000");
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+
+    });
+  });
+});

--- a/test/balancer/2brlusd_v3.js
+++ b/test/balancer/2brlusd_v3.js
@@ -1,0 +1,123 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+} = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("IERC20");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("BalancerStrategyV3Mainnet_2BRLUSD");
+
+// Developed and tested at blockNumber 38270720
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Polygon Mainnet Balancer 2BRLUSD V3", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x6a74649aCFD7822ae8Fb78463a9f2192752E5Aa2";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x4A0b73f0D13fF6d43e304a174697e3d5CFd310a4");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000");
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+
+    });
+  });
+});

--- a/test/balancer/2eur_ageur.js
+++ b/test/balancer/2eur_ageur.js
@@ -1,0 +1,141 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+} = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("IERC20");
+const IController = artifacts.require("IController");
+const Vault = artifacts.require("Vault");
+const VaultProxy = artifacts.require("VaultProxy");
+const StrategyProxy = artifacts.require("StrategyProxy.sol");
+const MigratableVault = artifacts.require("VaultMigratable_bal2EUR_agEUR");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("BalancerStrategyV3Mainnet_2EUR_agEUR");
+
+// Developed and tested at blockNumber 39015400
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Polygon Mainnet Balancer 2EUR-agEUR", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0xea25220Caf98e0097fB8401d8A44e2d4f2CEf093";
+  let vaultAddr = "0xE4E6055A7eB29F2Fa507ba7f8c4FAcc0C5ef9a2A";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xa48D164F6eB0EDC68bd03B56fa59E12F24499aD1");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, underlyingWhale, "10" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000");
+
+    await setupExternalContracts();
+
+    controller = await IController.at(addresses.Controller);
+    vault = await Vault.at(vaultAddr);
+    strategyImpl = await Strategy.new();
+    strategyProxy = await StrategyProxy.new(strategyImpl.address);
+    strategy = await Strategy.at(strategyProxy.address);
+    await strategy.initializeStrategy(addresses.Storage, vaultAddr);
+
+    console.log("Strategy deployed at:", strategy.address);
+
+    migratableVaultImpl = await MigratableVault.new();
+    await vault.scheduleUpgrade(migratableVaultImpl.address, {from: governance});
+    console.log("Vault upgrade announced. Waiting...");
+    await Utils.waitHours(13);
+    vault = await VaultProxy.at(vaultAddr);
+    await vault.upgrade({from: governance});
+
+    vault = await MigratableVault.at(vaultAddr);
+    await vault.migrateUnderlying(0, 0, 0, {from: governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+
+    });
+  });
+});

--- a/test/balancer/2eur_par.js
+++ b/test/balancer/2eur_par.js
@@ -1,0 +1,141 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+} = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("IERC20");
+const IController = artifacts.require("IController");
+const Vault = artifacts.require("Vault");
+const VaultProxy = artifacts.require("VaultProxy");
+const StrategyProxy = artifacts.require("StrategyProxy.sol");
+const MigratableVault = artifacts.require("VaultMigratable_bal2EUR_PAR");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("BalancerStrategyV3Mainnet_2EUR_PAR");
+
+// Developed and tested at blockNumber 39015400
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Polygon Mainnet Balancer 2EUR-PAR", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x6792c4E8A9efB4AB04e73E9b1c9Bf16b7cCC74c9";
+  let vaultAddr = "0x023E85B8415b460C56377525ED159aF9935E3370";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x7d60a4Cb5cA92E2Da965637025122296ea6854f9");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000");
+
+    await setupExternalContracts();
+
+    controller = await IController.at(addresses.Controller);
+    vault = await Vault.at(vaultAddr);
+    strategyImpl = await Strategy.new();
+    strategyProxy = await StrategyProxy.new(strategyImpl.address);
+    strategy = await Strategy.at(strategyProxy.address);
+    await strategy.initializeStrategy(addresses.Storage, vaultAddr);
+
+    console.log("Strategy deployed at:", strategy.address);
+
+    migratableVaultImpl = await MigratableVault.new();
+    await vault.scheduleUpgrade(migratableVaultImpl.address, {from: governance});
+    console.log("Vault upgrade announced. Waiting...");
+    await Utils.waitHours(13);
+    vault = await VaultProxy.at(vaultAddr);
+    await vault.upgrade({from: governance});
+
+    vault = await MigratableVault.at(vaultAddr);
+    await vault.migrateUnderlying(0, 0, 0, {from: governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+
+    });
+  });
+});

--- a/test/balancer/bbamusd_v3.js
+++ b/test/balancer/bbamusd_v3.js
@@ -1,0 +1,124 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+} = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("IERC20");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("BalancerStrategyV3Mainnet_bbamusd");
+
+// Developed and tested at blockNumber 38270720
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Polygon Mainnet Balancer bb-am-usd V3", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0xeC576a26335dE1C360d2FC9A68cbA6BA37af4a13";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x48e6B98ef6329f8f0A30eBB8c7C960330d648085");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000");
+    await send.ether(etherGiver, underlyingWhale, "100" + "000000000000000000");
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+
+    });
+  });
+});

--- a/test/balancer/maticx_v3.js
+++ b/test/balancer/maticx_v3.js
@@ -1,0 +1,141 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+} = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("IERC20");
+const IController = artifacts.require("IController");
+const Vault = artifacts.require("Vault");
+const VaultProxy = artifacts.require("VaultProxy");
+const StrategyProxy = artifacts.require("StrategyProxy.sol");
+const MigratableVault = artifacts.require("VaultMigratable_balMaticX");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("BalancerStrategyV3Mainnet_MaticX");
+
+// Developed and tested at blockNumber 38270720
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Polygon Mainnet Balancer MaticX V3", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x4A16aC778F418b531d89a0F7BF6a4B2d12Fd252A";
+  let vaultAddr = "0x62119D3AEa375B0e3Cee7683b0aFDDa836C0676A";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xb20fC01D21A50d2C734C4a1262B4404d41fA7BF0");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000");
+
+    await setupExternalContracts();
+
+    controller = await IController.at(addresses.Controller);
+    vault = await Vault.at(vaultAddr);
+    strategyImpl = await Strategy.new();
+    strategyProxy = await StrategyProxy.new(strategyImpl.address);
+    strategy = await Strategy.at(strategyProxy.address);
+    await strategy.initializeStrategy(addresses.Storage, vaultAddr);
+
+    console.log(strategy.address);
+
+    migratableVaultImpl = await MigratableVault.new();
+    await vault.scheduleUpgrade(migratableVaultImpl.address, {from: governance});
+    console.log("Vault upgrade announced. Waiting...");
+    await Utils.waitHours(13);
+    vault = await VaultProxy.at(vaultAddr);
+    await vault.upgrade({from: governance});
+
+    vault = await MigratableVault.at(vaultAddr);
+    await vault.migrateUnderlying(0, 0, 0, {from: governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+
+    });
+  });
+});

--- a/test/balancer/stmatic_v3.js
+++ b/test/balancer/stmatic_v3.js
@@ -1,0 +1,141 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+} = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("IERC20");
+const IController = artifacts.require("IController");
+const Vault = artifacts.require("Vault");
+const VaultProxy = artifacts.require("VaultProxy");
+const StrategyProxy = artifacts.require("StrategyProxy.sol");
+const MigratableVault = artifacts.require("VaultMigratable_balStMatic");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("BalancerStrategyV3Mainnet_stMatic");
+
+// Developed and tested at blockNumber 38270720
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Polygon Mainnet Balancer stMatic V3", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x7153D2ef9F14a6b1Bb2Ed822745f65E58d836C3F";
+  let vaultAddr = "0xe0fbF2ea37d731187e6E85a45Cc1D5D3b66335aa";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x8159462d255C1D24915CB51ec361F700174cD994");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000");
+
+    await setupExternalContracts();
+
+    controller = await IController.at(addresses.Controller);
+    vault = await Vault.at(vaultAddr);
+    strategyImpl = await Strategy.new();
+    strategyProxy = await StrategyProxy.new(strategyImpl.address);
+    strategy = await Strategy.at(strategyProxy.address);
+    await strategy.initializeStrategy(addresses.Storage, vaultAddr);
+
+    console.log(strategy.address);
+
+    migratableVaultImpl = await MigratableVault.new();
+    await vault.scheduleUpgrade(migratableVaultImpl.address, {from: governance});
+    console.log("Vault upgrade announced. Waiting...");
+    await Utils.waitHours(13);
+    vault = await VaultProxy.at(vaultAddr);
+    await vault.upgrade({from: governance});
+
+    vault = await MigratableVault.at(vaultAddr);
+    await vault.migrateUnderlying(0, 0, 0, {from: governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+
+    });
+  });
+});

--- a/test/balancer/tetubal_v3.js
+++ b/test/balancer/tetubal_v3.js
@@ -1,0 +1,123 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+} = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("IERC20");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("BalancerStrategyV3Mainnet_tetuBal");
+
+// Developed and tested at blockNumber 38270720
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Polygon Mainnet Balancer tetuBal V3", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0xABfE00f81c2b9734C2FeCec3f1996E18611ce658";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xB797AdfB7b268faeaA90CAdBfEd464C76ee599Cd");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000");
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 1565*5;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/1565))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1565))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+
+    });
+  });
+});


### PR DESCRIPTION
Updated balancer strategy and added new vaults.

Also includes updates to 2 existing vaults, which will need to be migrated to a new underlying LP token. The vault implementations that include the migration function can be found in `contracts/base/migration/`. Note that these contracts have been deployed with some `console.log()` statements. I believe these should help to set the three `minOutput` arguments after simulation, so we can protect the migration from slippage/frontrunning.

These are the vaults that need to be upgraded:
balMaticX: `0x62119D3AEa375B0e3Cee7683b0aFDDa836C0676A`
New implementation: `0x7ca2C99238B906644bEDC79De4e1D2fD65da181d`

balStMatic: `0xe0fbF2ea37d731187e6E85a45Cc1D5D3b66335aa`
New implementation: `0xda3C5439D8b0eC86121CD91BD6149cEb49C17f94`

I tested the upgrade for both in simulation. The process would simply be to call `scheduleUpgrade(address newImplementation)`, wait out the 12h timelock, call `upgrade()` and then call `migrateUnderlying()` with reasonable output limits that can be found in a simulation run.

Let me know if there are any comments or questions.